### PR TITLE
Error for complex statement in zremrangebyscore

### DIFF
--- a/spec/commands/zremrangebyscore_spec.rb
+++ b/spec/commands/zremrangebyscore_spec.rb
@@ -17,5 +17,12 @@ describe "#zremrangebyscore(key, min, max)" do
     @redises.zremrangebyscore(@key, 2, 3)
     @redises.zrange(@key, 0, -1).should == %w[Washington Madison]
   end
+
+  # As seen in http://redis.io/commands/zremrangebyscore
+  it "removes the elements for complex statements" do
+    @redises.zremrangebyscore(@key, '-inf', '(4')
+    @redises.zrange(@key, 0, -1).should == %w[Madison]
+  end
+
   it_should_behave_like "a zset-only command"
 end


### PR DESCRIPTION
I've added a test for zremrangebyscore.

I got this error:
ArgumentError: comparison of String with 1314195276 failed
    mock_redis (0.1.0) lib/mock_redis/zset_methods.rb:59:in `<='
    ...

For this statement:

MockRedis.new.zremrangebyscore('stream:users:2:friends:images', '-inf', "(1314195102" )

The min & max params don't get mapped on "+inf", "-inf", "(<int>" and ")<int>" for range methods, right?

Example for this:
http://redis.io/commands/zremrangebyscore

Greetz
SweeD
