### PR TITLE
Add support for block syntax

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -21,8 +21,8 @@ class MockRedis
     super || @db.respond_to?(method, include_private)
   end
 
-  def method_missing(method, *args)
-    @db.send(method, *args)
+  def method_missing(method, *args, &block)
+    @db.send(method, *args, &block)
   end
 
   def initialize_copy(source)

--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -60,7 +60,12 @@ class MockRedis
         raise RuntimeError, "ERR MULTI calls can not be nested"
       end
       @in_multi = true
-      'OK'
+      if block_given?
+        yield(self)
+        self.exec
+      else
+        'OK'
+      end
     end
 
     def unwatch

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -17,6 +17,30 @@ describe 'transactions (multi/exec/discard)' do
       end.should raise_error(RuntimeError)
     end
   end
+  context "#blocks" do
+    before(:each) do
+      @mock = @redises.mock # Mock only since the block syntax seems to confuse the multiplexer
+    end
+
+    it "implicitly runs exec when finished" do
+      @mock.set("counter", 5)
+      @mock.multi do
+        @mock.set("test", 1)
+        @mock.incr("counter")
+      end
+      @mock.get("counter").should == "6"
+      @mock.get("test").should == "1"
+    end
+
+    it "forbids nesting via blocks" do
+      @mock.multi do
+        lambda do
+          @mock.multi do
+          end
+        end.should raise_error(RuntimeError)
+      end
+    end
+  end
 
   context "#discard" do
     it "responds with 'OK' after #multi" do


### PR DESCRIPTION
This change allows mock_redis to allow the same block syntax as redis-rb does.  Such as:

```
redis.multi do
  redis.set(key, value)
  redis.incr(counter)
end
```
