### PR TITLE
Support redisrb's hash operator for get/set

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -24,6 +24,10 @@ class MockRedis
       data[key]
     end
 
+    def [](key)
+      get(key)
+    end
+
     def getbit(key, offset)
       assert_stringy(key)
 
@@ -106,6 +110,10 @@ class MockRedis
     def set(key, value)
       data[key] = value.to_s
       'OK'
+    end
+
+    def []=(key, value)
+      set(key, value)
     end
 
     def setbit(key, offset, value)

--- a/spec/commands/hash_operator_spec.rb
+++ b/spec/commands/hash_operator_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "#[](key)" do
+  before do
+    @key = 'mock-redis-test:hash_operator'
+  end
+
+  it "returns nil for a nonexistent value" do
+    @redises['mock-redis-test:does-not-exist'].should be_nil
+  end
+
+  it "returns a stored string value" do
+    @redises[@key] = 'forsooth'
+    @redises[@key].should == 'forsooth'
+  end
+
+  it "treats integers as strings" do
+    @redises[@key] = 100
+    @redises[@key].should == "100"
+  end
+end


### PR DESCRIPTION
Redisrb supports the hash operator as aliases for get and set.  This allows mock_redis to support that syntax as well.
