### PR TITLE
Fix for bundler issue with Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,12 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
+begin
+  Bundler.setup(:default, :development)
+rescue Bundler::BundlerError => e
+  $stderr.puts e.message
+  $stderr.puts "Run `bundle install` to install missing gems"
+  exit e.status_code
+end
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|


### PR DESCRIPTION
If I ran 'bundle && rake' I was getting the following:

```
    ((v0.2.0)) $ bundle && rake
    Using ZenTest (4.6.2) 
    Using archive-tar-minitar (0.5.2) 
    Using columnize (0.3.4) 
    Using diff-lcs (1.1.3) 
    Using ruby_core_source (0.1.5) 
    Using linecache19 (0.5.12) 
    Using mock_redis (0.2.0) from source at . 
    Using redis (2.2.2) 
    Using rspec-core (2.6.4) 
    Using rspec-expectations (2.6.0) 
    Using rspec-mocks (2.6.0) 
    Using rspec (2.6.0) 
    Using ruby-debug-base19 (0.11.25) 
    Using ruby-debug19 (0.11.6) 
    Using bundler (1.0.18) 
    Your bundle is complete! It was installed into ./vendor/bundler
    (in /Users/ej/projects/mock_redis)
    rake aborted!
    no such file to load -- rspec/core/rake_task
    /Users/ej/projects/mock_redis/Rakefile:4:in `<top (required)>'
    (See full trace by running task with --trace)
```

This change should make sure that bundler sets up the environment properly before trying to load rspec
