### PR TITLE
Fixed zset methods to handle non-string members

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -11,7 +11,7 @@ class MockRedis
       assert_scorey(score)
 
       retval = !zscore(key, member)
-      with_zset_at(key) {|z| z.add(score, member)}
+      with_zset_at(key) {|z| z.add(score, member.to_s)}
       retval
     end
 
@@ -32,6 +32,7 @@ class MockRedis
 
     def zincrby(key, increment, member)
       assert_scorey(increment)
+      member = member.to_s
       with_zset_at(key) do |z|
         old_score = z.include?(member) ? z.score(member) : 0
         new_score = old_score + increment
@@ -61,11 +62,11 @@ class MockRedis
     end
 
     def zrank(key, member)
-      with_zset_at(key) {|z| z.sorted_members.index(member) }
+      with_zset_at(key) {|z| z.sorted_members.index(member.to_s) }
     end
 
     def zrem(key, member)
-      with_zset_at(key) {|z| !!z.delete?(member)}
+      with_zset_at(key) {|z| !!z.delete?(member.to_s)}
     end
 
     def zrevrange(key, start, stop, options={})
@@ -97,12 +98,12 @@ class MockRedis
     end
 
     def zrevrank(key, member)
-      with_zset_at(key) {|z| z.sorted_members.reverse.index(member) }
+      with_zset_at(key) {|z| z.sorted_members.reverse.index(member.to_s) }
     end
 
     def zscore(key, member)
       with_zset_at(key) do |z|
-        score = z.score(member)
+        score = z.score(member.to_s)
         score.to_s if score
       end
     end

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -17,6 +17,12 @@ describe "#zadd(key, score, member)" do
     @redises.zrange(@key, 0, -1).should == ['foo']
   end
 
+  it "treats integer members as strings" do
+    member = 11
+    @redises.zadd(@key, 1, member)
+    @redises.zrange(@key, 0, -1).should == [member.to_s]
+  end
+
   it "updates the score" do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'foo')

--- a/spec/commands/zincrby_spec.rb
+++ b/spec/commands/zincrby_spec.rb
@@ -15,6 +15,13 @@ describe "#zincrby(key, increment, member)" do
     @redises.zscore(@key, 'bert').should == "11"
   end
 
+  it "handles integer members correctly" do
+    member = 11
+    @redises.zadd(@key, 1, member)
+    @redises.zincrby(@key, 1, member)
+    @redises.zscore(@key, member).should == "2"
+  end
+
   it "adds missing members with score increment" do
     @redises.zincrby(@key, 5.5, 'bigbird').should == "5.5"
   end

--- a/spec/commands/zrank_spec.rb
+++ b/spec/commands/zrank_spec.rb
@@ -19,5 +19,11 @@ describe "#zrank(key, member)" do
     @redises.zrank(@key, 'three').should == 2
   end
 
+  it "handles integer members correctly" do
+    member = 11
+    @redises.zadd(@key, 4, member)
+    @redises.zrank(@key, member).should == 3
+  end
+
   it_should_behave_like "a zset-only command"
 end

--- a/spec/commands/zrem_spec.rb
+++ b/spec/commands/zrem_spec.rb
@@ -21,5 +21,12 @@ describe "#zrem(key, member)" do
     @redises.zrange(@key, 0, -1).should == ['two']
   end
 
+  it "removes integer member from the set" do
+    member = 11
+    @redises.zadd(@key, 3, member)
+    @redises.zrem(@key, member).should be_true
+    @redises.zrange(@key, 0, -1).should == ['one', 'two']
+  end
+
   it_should_behave_like "a zset-only command"
 end

--- a/spec/commands/zrevrank_spec.rb
+++ b/spec/commands/zrevrank_spec.rb
@@ -19,5 +19,11 @@ describe "#zrevrank(key, member)" do
     @redises.zrevrank(@key, 'three').should == 0
   end
 
+  it "handles integer members correctly" do
+    member = 11
+    @redises.zadd(@key, 4, member)
+    @redises.zrevrank(@key, member).should == 0
+  end
+
   it_should_behave_like "a zset-only command"
 end

--- a/spec/commands/zscore_spec.rb
+++ b/spec/commands/zscore_spec.rb
@@ -8,6 +8,12 @@ describe "#zscore(key, member)" do
     @redises.zscore(@key, 'foo').should == "0.25"
   end
 
+  it "handles integer members correctly" do
+    member = 11
+    @redises.zadd(@key, 0.25, member).should be_true
+    @redises.zscore(@key, member).should == "0.25"
+  end
+
   it "returns nil if member is not present in the set" do
     @redises.zscore(@key, 'foo').should be_nil
   end


### PR DESCRIPTION
Passing a non-string (e.g. integer) member caused incorrect behavior 
because Redis converts all members to strings.
Modified: zadd, zincrby, zrank, zrem, zrevrank, and zscore.

I started with an issue with zadd that spread to zrem, at which point I just decided to go through all of the sorted set commands looking for this problem.  I think I got them all.  I don't know if other data types have a similar problem.  I'll look if I have some free time.

thanks,
Charles.
