### PR TITLE
Fixed hash methods to handle non-string fields

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -8,16 +8,16 @@ class MockRedis
 
     def hdel(key, field)
       with_hash_at(key) do |hash|
-        hash.delete(field) ? 1 : 0
+        hash.delete(field.to_s) ? 1 : 0
       end
     end
 
     def hexists(key, field)
-      with_hash_at(key) {|h| h.has_key?(field)}
+      with_hash_at(key) {|h| h.has_key?(field.to_s)}
     end
 
     def hget(key, field)
-      with_hash_at(key) {|h| h[field]}
+      with_hash_at(key) {|h| h[field.to_s]}
     end
 
     def hgetall(key)
@@ -26,6 +26,7 @@ class MockRedis
 
     def hincrby(key, field, increment)
       with_hash_at(key) do |hash|
+        field = field.to_s
         unless can_incr?(data[key][field])
           raise RuntimeError, "ERR hash value is not an integer"
         end
@@ -80,7 +81,7 @@ class MockRedis
     end
 
     def hset(key, field, value)
-      with_hash_at(key) {|h| h[field] = value.to_s}
+      with_hash_at(key) {|h| h[field.to_s] = value.to_s}
       true
     end
 

--- a/spec/commands/hdel_spec.rb
+++ b/spec/commands/hdel_spec.rb
@@ -20,6 +20,13 @@ describe "#hdel(key, field)" do
     @redises.hget(@key, 'k1').should be_nil
   end
 
+  it "treats the field as a string" do
+    field = 2
+    @redises.hset(@key, field, 'two')
+    @redises.hdel(@key, field)
+    @redises.hget(@key, field).should be_nil
+  end
+
   it "removes only the field specified" do
     @redises.hdel(@key, 'k1')
     @redises.hget(@key, 'k2').should == 'v2'

--- a/spec/commands/hexists_spec.rb
+++ b/spec/commands/hexists_spec.rb
@@ -14,6 +14,11 @@ describe "#hexists(key, field)" do
     @redises.hexists(@key, 'nonesuch').should be_false
   end
 
+  it "treats the field as a string" do
+    @redises.hset(@key, 1, 'one')
+    @redises.hexists(@key, 1).should be_true
+  end
+
   it "returns nil when there is no such key" do
     @redises.hexists('mock-redis-test:nonesuch', 'key').should be_false
   end

--- a/spec/commands/hget_spec.rb
+++ b/spec/commands/hget_spec.rb
@@ -11,6 +11,11 @@ describe "#hget(key, field)" do
     @redises.hget(@key, 'k1').should == 'v1'
   end
 
+  it "treats the field as a string" do
+    @redises.hset(@key, '3', 'v3')
+    @redises.hget(@key, 3).should == 'v3'
+  end
+
   it "returns nil when there is no such field" do
     @redises.hget(@key, 'nonesuch').should be_nil
   end

--- a/spec/commands/hincrby_spec.rb
+++ b/spec/commands/hincrby_spec.rb
@@ -35,6 +35,12 @@ describe '#hincrby(key, field, increment)' do
     @redises.hincrby(@key, @field, "2").should == 2
   end
 
+  it "treats the field as a string" do
+    field = 11
+    @redises.hset(@key, field, 2)
+    @redises.hincrby(@key, field, 2).should == 4
+  end
+
   it "raises an error if the value does not look like an integer" do
     @redises.hset(@key, @field, "one")
     lambda do

--- a/spec/commands/hmget_spec.rb
+++ b/spec/commands/hmget_spec.rb
@@ -11,6 +11,12 @@ describe "#hmget(key, field [, field, ...])" do
     @redises.hmget(@key, 'k1', 'k2').sort.should == %w[v1 v2]
   end
 
+  it "treats the fielsd as strings" do
+    @redises.hset(@key, 1, 'one')
+    @redises.hset(@key, 2, 'two')
+    @redises.hmget(@key, 1, 2).sort.should == %w[one two]
+  end
+
   it "returns nils when there are no such fields" do
     @redises.hmget(@key, 'k1', 'mock-redis-test:nonesuch').
       should == ['v1', nil]

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -19,5 +19,10 @@ describe "#hset(key, field)" do
     @redises.hget(@key, 'num').should == "1"
   end
 
+  it "stores fields as strings" do
+    @redises.hset(@key, 1, "one")
+    @redises.hget(@key, "1").should == "one"
+  end
+
   it_should_behave_like "a hash-only command"
 end

--- a/spec/commands/hsetnx_spec.rb
+++ b/spec/commands/hsetnx_spec.rb
@@ -35,5 +35,10 @@ describe "#hsetnx(key, field)" do
     @redises.hget(@key, 'num').should == "1"
   end
 
+  it "stores fields as strings" do
+    @redises.hsetnx(@key, 1, "one")
+    @redises.hget(@key, "1").should == "one"
+  end
+
   it_should_behave_like "a hash-only command"
 end


### PR DESCRIPTION
Passing a non-string (e.g. integer) member caused incorrect behavior
because Redis converts all members to strings.
Modified: hdel, hexists, hget, hincrby, and hset.

(Each time I start using a new data type in Redis, it seems I insist on using non-string values, and I uncover some bug.  :-)

Charles.
