### PR TITLE
srandmember doesn't actually give a random member

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -73,7 +73,8 @@ class MockRedis
     end
 
     def srandmember(key)
-      with_set_at(key, &:first)
+      members = with_set_at(key, &:to_a)
+      members[rand(members.length)]
     end
 
     def srem(key, member)


### PR DESCRIPTION
I rewrote srandmember to actually get a random member.

I was not able to write the appropriate unit tests because I kept getting errors like this:

```
  1) #srandmember(key) returns a member of the set
     Failure/Error: @redises.srandmember(@key).should_not be_nil
     RedisMultiplexer::MismatchedResponse:
       Mock failure: responses not equal.
       Redis.srandmember(["mock-redis-test:srandmember"]) returned "value2"
       MockRedis.srandmember(["mock-redis-test:srandmember"]) returned "value1"
     # ./spec/support/redis_multiplexer.rb:22:in `method_missing'
     # ./spec/commands/srandmember_spec.rb:12:in `block (2 levels) in <top (required)>'
```
