### PR TITLE
Throw an error when trying to rename a non-existent key

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -304,7 +304,9 @@ class MockRedis
     end
 
     def rename(key, newkey)
-      if key == newkey
+      if !data.include?(key)
+        raise RuntimeError, "ERR no such key"
+      elsif key == newkey
         raise RuntimeError, "ERR source and destination objects are the same"
       end
       data[newkey] = data.delete(key)

--- a/spec/commands/rename_spec.rb
+++ b/spec/commands/rename_spec.rb
@@ -17,6 +17,12 @@ describe '#rename(key, newkey)' do
     @redises.get(@newkey).should == "oof"
   end
 
+  it "raises an error when the source key does not exist" do
+    lambda do
+      @redises.rename("foo", @key)
+    end.should raise_error(RuntimeError)
+  end
+
   it "raises an error when key == newkey" do
     lambda do
       @redises.rename(@key, @key)


### PR DESCRIPTION
Redis will barf with 'ERR no such key' when you try to rename keys that don't exist. Give it a try at http://redis.io/commands/rename
