### PR TITLE
Handle exceptions in transaction wrapper

### DIFF
--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -61,8 +61,13 @@ class MockRedis
       end
       @in_multi = true
       if block_given?
-        yield(self)
-        self.exec
+        begin
+          yield(self)
+          self.exec
+        rescue => e
+          self.discard
+          raise e
+        end
       else
         'OK'
       end

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -16,6 +16,23 @@ describe 'transactions (multi/exec/discard)' do
         @redises.multi
       end.should raise_error(RuntimeError)
     end
+
+    it "cleanup the state of tansaction wrapper if an exception occurs while a transaction is being processed" do
+      lambda do
+        @redises.mock.multi do |r|
+          raise "i'm a command that fails"
+        end
+      end.should raise_error(RuntimeError)
+
+      # before the fix this used to raised a #<RuntimeError: ERR MULTI calls can not be nested>
+      lambda do
+        @redises.mock.multi do |r|
+          # do stuff that succeed
+          s.set(nil, 'string')
+        end
+      end.should_not raise_error(RuntimeError)
+
+    end
   end
 
   context "#blocks" do


### PR DESCRIPTION
When an exception happens inside a **mutli** block the state of the transaction wrapper is not being cleaned up.
Causing later calls to **multi** to fail with a #<RuntimeError: ERR MULTI calls can not be nested>. 

```
    redis.multi do |r|
        something_that_raise_exception(r)
    end

     # later on...
    redis.multi do |r|  # this raises a #<RuntimeError: ERR MULTI calls can not be nested>. 
        r.set('a-key, 'a-value')  
    end

```
