### PR TITLE
Added zcount support for -inf and +inf

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -20,13 +20,11 @@ class MockRedis
     end
 
     def zcount(key, min, max)
-      assert_scorey(min, 'min or max')
-      assert_scorey(max, 'min or max')
+      assert_scorey(min, 'min or max') unless min == '-inf'
+      assert_scorey(max, 'min or max') unless max == '+inf'
 
-      with_zset_at(key) do |z|
-        z.count do |score, _|
-          score >= min && score <= max
-        end
+      with_zset_at(key) do |zset|
+        zset.in_range(min, max).size
       end
     end
 

--- a/spec/commands/zcount_spec.rb
+++ b/spec/commands/zcount_spec.rb
@@ -17,6 +17,14 @@ describe "#zcount(key, min, max)" do
     @redises.zcount(@key, 100, 200).should == 0
   end
 
+  it "returns count of all elements when -inf to +inf" do
+    @redises.zcount(@key, "-inf", '+inf').should == 4
+  end
+
+  it "returns a proper count of elements using +inf upper bound" do
+    @redises.zcount(@key, 3, "+inf").should == 2
+  end
+
   it_should_behave_like "arg 1 is a score"
   it_should_behave_like "arg 2 is a score"
   it_should_behave_like "a zset-only command"


### PR DESCRIPTION
While testing another project I got this error while passing "+inf" to mock_redis.zcount

```
RuntimeError: ERR min or max is not a double
```

Since Redis itself doesn't have this limitation, I allow zcount to accept "-inf" and "+inf" as well. The zset in_range method seems to already appropriately check these conditions, so I went ahead and used that. 

Tests are included and run clean. Please let me know if you have any questions!
