### PR TITLE
Allow `sadd` to take multiple args

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -6,8 +6,13 @@ class MockRedis
     include Assertions
     include UtilityMethods
 
-    def sadd(key, member)
-      with_set_at(key) {|s| !!s.add?(member.to_s)}
+    def sadd(key, *members)
+      raise ArgumentError, "wrong number of arguments (1 for 2..)" if members.empty?
+      with_set_at(key) do |s|
+        members.map do |member|
+          s.add?(member.to_s)
+        end.compact.count
+      end
     end
 
     def scard(key)

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -3,18 +3,23 @@ require 'spec_helper'
 describe '#sadd(key, member)' do
   before { @key = 'mock-redis-test:sadd' }
 
-  it "returns true if the set did not already contain member" do
-    @redises.sadd(@key, 1).should be_true
+  it "returns 1 if the set did not already contain member" do
+    @redises.sadd(@key, 1).should == 1
   end
 
-  it "returns false if the set did already contain member" do
+  it "returns 0 if the set did already contain member" do
     @redises.sadd(@key, 1)
-    @redises.sadd(@key, 1).should be_false
+    @redises.sadd(@key, 1).should == 0
+  end
+
+  it "returns the number of newly added members" do
+    @redises.sadd(@key, 1)
+    @redises.sadd(@key, 1, 2, 3, 2).should == 2
   end
 
   it "adds member to the set" do
     @redises.sadd(@key, 1)
-    @redises.sadd(@key, 2)
+    @redises.sadd(@key, 2, 1)
     @redises.smembers(@key).should == %w[2 1]
   end
 


### PR DESCRIPTION
- To match redis 3.0.0
- Also update respective specs
