### PR TITLE
Support connecting to Redis via the MockRedis#connect method.

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -23,6 +23,10 @@ class MockRedis
      :db => 0,
   }
 
+  def self.connect(*args)
+    new(*args)
+  end
+
   def initialize(*args)
     @options = _parse_options(args.first)
 

--- a/spec/mock_redis_spec.rb
+++ b/spec/mock_redis_spec.rb
@@ -16,6 +16,22 @@ describe MockRedis do
     it "should have an id equal to redis url" do
       @mock.id.should == "redis://127.0.0.1:6379/1"
     end
+
+    context "when connecting to redis" do
+      before do
+        @mock = MockRedis.connect(:url => "redis://127.0.0.1:6379/0")
+      end
+
+      it "should correctly parse options" do
+        @mock.host.should == "127.0.0.1"
+        @mock.port.should == 6379
+        @mock.db.should == 0
+      end
+
+      it "should have an id equal to redis url" do
+        @mock.id.should == "redis://127.0.0.1:6379/0"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
The [Sidekiq](https://github.com/mperham/sidekiq) gem uses `Redis.connect(*args)` and not Redis.new for initializing the Redis object. When I set `Redis = MockRedis` in spec_helper.rb it (previously) complained about no method `connect` for MockRedis class. Thus the motivation for this method.
