### PR TITLE
Make the SADD method Redis 2.4 compliant

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -6,8 +6,18 @@ class MockRedis
     include Assertions
     include UtilityMethods
 
-    def sadd(key, member)
-      with_set_at(key) {|s| !!s.add?(member.to_s)}
+    def sadd(key, members)
+      members = [members].flatten.map(&:to_s)
+
+      with_set_at(key) do |s|
+        if members.size > 1
+          size_before = s.size
+          members.reverse.each {|m| s << m}
+          s.size - size_before
+        else
+          !!s.add?(members.first)
+        end
+      end
     end
 
     def scard(key)

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -18,5 +18,24 @@ describe '#sadd(key, member)' do
     @redises.smembers(@key).should == %w[2 1]
   end
 
+  describe 'adding multiple members at once' do
+
+    it "returns the amount of added members" do
+      @redises.sadd(@key, [1,2,3]).should == 3
+      @redises.sadd(@key, [1,2,3,4]).should == 1
+    end
+
+    it "returns 0 if the set did already contain all members" do
+      @redises.sadd(@key, [1,2,3])
+      @redises.sadd(@key, [1,2,3]).should == 0
+    end
+
+    it "adds the members to the set" do
+      @redises.sadd(@key, [1,2,3])
+      @redises.smembers(@key).should == %w[1 2 3]
+    end
+
+  end
+
   it_should_behave_like "a set-only command"
 end


### PR DESCRIPTION
Since Redis 2.4 the `SADD` command allows you to add multiple set members at once [[1](http://redis.io/commands/sadd)]. Since we're relying on this functionality and don't want to use a read Redis connection while testing I make your `sadd` method compliant with that behavior.

Thanks for this gem, really useful.

Best Regards
Dirk
