### PR TITLE
Minimal WATCH support

### DIFF
--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -78,7 +78,7 @@ class MockRedis
     end
 
     def watch(_)
-      nil
+      yield self if block_given?
     end
 
   end

--- a/spec/commands/watch_spec.rb
+++ b/spec/commands/watch_spec.rb
@@ -4,4 +4,13 @@ describe '#watch(key)' do
   it "responds with nil" do
     @redises.watch('mock-redis-test').should be_nil
   end
+
+  it 'EXECs its MULTI on successes' do
+    @redises.watch 'foo' do
+      @redises.multi do |multi|
+        multi.set 'bar', 'baz'
+      end
+    end
+    @redises.get('bar').should eq('baz')
+  end
 end


### PR DESCRIPTION
Currently MockRedis returns `nil` on `#watch` calls, which means any blocks passed to `#watch` are happily ignored.

This pull request adds minimal `WATCH` support (by simply `yield`ing the passed block). It’s far from ideal (it doesn’t track the watched key changes at all), but I think it’s still better than the current ‘no action’ approach; in particular, it makes my tests that use MockRedis pass when encountering `#watch`-using code, rather than ignoring the passed block silently and blowing up sometime later. :)
