### PR TITLE
Support Redis#location (alias the Redis#id) field

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -40,6 +40,7 @@ class MockRedis
   def id
     "redis://#{self.host}:#{self.port}/#{self.db}"
   end
+  alias :location :id
 
   def call(command, &block)
      self.send(*command)

--- a/spec/mock_redis_spec.rb
+++ b/spec/mock_redis_spec.rb
@@ -13,8 +13,9 @@ describe MockRedis do
       @mock.db.should == 1
     end
 
-    it "should have an id equal to redis url" do
+    it "should have an id and location equal to redis url" do
       @mock.id.should == "redis://127.0.0.1:6379/1"
+      @mock.location.should == "redis://127.0.0.1:6379/1"
     end
 
     context "when connecting to redis" do
@@ -30,6 +31,7 @@ describe MockRedis do
 
       it "should have an id equal to redis url" do
         @mock.id.should == "redis://127.0.0.1:6379/0"
+        @mock.location.should == "redis://127.0.0.1:6379/0"
       end
     end
   end


### PR DESCRIPTION
The [Sidekiq](https://github.com/mperham/sidekiq) gem uses `Redis.location` for the admin ui. Thus the motivation for this method.
