### PR TITLE
specs pass with 2.6 final Redis release

### DIFF
--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -97,6 +97,9 @@ class MockRedis
     end
 
     def lrem(key, count, value)
+      unless looks_like_integer?(count.to_s)
+        raise Redis::CommandError, "ERR value is not an integer or out of range"
+      end
       count = count.to_i
       value = value.to_s
 

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -42,8 +42,8 @@ class MockRedis
     end
 
     def zcount(key, min, max)
-      assert_scorey(min, 'min or max') unless min == '-inf'
-      assert_scorey(max, 'min or max') unless max == '+inf'
+      assert_scorey(min, 'ERR min or max is not a float') unless min == '-inf'
+      assert_scorey(max, 'ERR min or max is not a float') unless max == '+inf'
 
       with_zset_at(key) do |zset|
         zset.in_range(min, max).size
@@ -230,9 +230,9 @@ class MockRedis
       !!Float(x) rescue false
     end
 
-    def assert_scorey(value, what='value')
+    def assert_scorey(value, message = "ERR value is not a valid float")
       unless looks_like_float?(value)
-        raise Redis::CommandError, "ERR #{what} is not a double"
+        raise Redis::CommandError, message
       end
     end
 

--- a/spec/commands/lrem_spec.rb
+++ b/spec/commands/lrem_spec.rb
@@ -61,9 +61,10 @@ describe "#lrem(key, count, value)" do
     @redises.lrem(@key, 0, "beer").should == 0
   end
 
-  it "treats non-integer count as 0" do
-    @redises.lrem(@key, 'foo', 'bottles').should == 3
-    @redises.lrange(@key, 0, -1).grep(/bottles/).should be_empty
+  it "raises an error if the value does not look like an integer" do
+    lambda do
+      @redises.lrem(@key, 'foo', 'bottles')
+    end.should raise_error(RuntimeError)
   end
 
   it "removes empty lists" do


### PR DESCRIPTION
Redis 2.6.0 has slightly different behaviour that causes some existing specs to break.

Pull request has fixes for broken specs with 2.6.0

Running on OSX with homebrew installed Redis 2.6.0, and redis 3.0.2 gem.
