### PR TITLE
add incrbyfloat operation

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -372,6 +372,10 @@ class MockRedis
       value.nil? || looks_like_integer?(value)
     end
 
+    def can_incr_float?(value)
+      value.nil? || looks_like_float?(value)
+    end
+
     def extract_timeout(arglist)
       timeout = assert_valid_timeout(arglist.last)
       [arglist[0..-2], arglist.last]

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -75,6 +75,22 @@ class MockRedis
       new_value
     end
 
+    def incrbyfloat(key, n)
+      assert_stringy(key)
+      unless can_incr_float?(data[key])
+        raise Redis::CommandError, "ERR value is not a valid float"
+      end
+
+      unless looks_like_float?(n.to_s)
+        raise Redis::CommandError, "ERR value is not a valid float"
+      end
+
+      new_value = data[key].to_f + n.to_f
+      data[key] = new_value.to_s
+      # for some reason, redis-rb doesn't return this as a string.
+      new_value
+    end
+
     def mget(*keys)
       assert_has_args(keys, 'mget')
 

--- a/spec/commands/incrbyfloat_spec.rb
+++ b/spec/commands/incrbyfloat_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe '#incrbyfloat(key, increment)' do
+  before { @key = 'mock-redis-test:65374' }
+
+  it "returns the value after the increment" do
+    @redises.set(@key, 2.0)
+    @redises.incrbyfloat(@key, 2.1).should be_within(0.0001).of(4.1)
+  end
+
+  it "treats a missing key like 0" do
+    @redises.incrbyfloat(@key, 1.2).should be_within(0.0001).of(1.2)
+  end
+
+  it "increments negative numbers" do
+    @redises.set(@key, -10.4)
+    @redises.incrbyfloat(@key, 2.3).should be_within(0.0001).of(-8.1)
+  end
+
+  it "works multiple times" do
+    @redises.incrbyfloat(@key, 2.1).should be_within(0.0001).of(2.1)
+    @redises.incrbyfloat(@key, 2.2).should be_within(0.0001).of(4.3)
+    @redises.incrbyfloat(@key, 2.3).should be_within(0.0001).of(6.6)
+  end
+
+  it "accepts an float-ish string" do
+    @redises.incrbyfloat(@key, "2.2").should be_within(0.0001).of(2.2)
+  end
+
+  it "raises an error if the value does not look like an float" do
+    @redises.set(@key, "one.two")
+    lambda do
+      @redises.incrbyfloat(@key, 1)
+    end.should raise_error(RuntimeError)
+  end
+
+  it "raises an error if the delta does not look like an float" do
+    lambda do
+      @redises.incrbyfloat(@key, "foobar.baz")
+    end.should raise_error(RuntimeError)
+  end
+
+  it_should_behave_like "a string-only command"
+end

--- a/spec/support/redis_multiplexer.rb
+++ b/spec/support/redis_multiplexer.rb
@@ -69,6 +69,9 @@ class RedisMultiplexer < BlankSlate
       a.collect(&:to_s).sort == b.collect(&:to_s).sort
     elsif a.is_a?(Exception) && b.is_a?(Exception)
       a.class == b.class && a.message == b.message
+    elsif a.is_a?(Float) && b.is_a?(Float)
+      delta = [a.abs, b.abs].min / 1_000_000.0
+      (a - b).abs < delta
     else
       false
     end


### PR DESCRIPTION
Add support for new `incrbyfloat` operation added in Redis 2.6.0

Note that this pull request's specs are breaking with Redis 2.6.0, but that is due to changes in Redis's behaviour. 

Everything passes OK if this is applied in combination with my other pull request https://github.com/causes/mock_redis/pull/32 to fix up the existing spec breakages caused by Redis 2.6.0 changes.
