### PR TITLE
Fixed lrange to return [] when start is too large

### DIFF
--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -93,7 +93,7 @@ class MockRedis
     end
 
     def lrange(key, start, stop)
-      with_list_at(key) {|l| l[start..stop]}
+      with_list_at(key) {|l| start < l.size ? l[start..stop] : []}
     end
 
     def lrem(key, count, value)

--- a/spec/commands/lrange_spec.rb
+++ b/spec/commands/lrange_spec.rb
@@ -27,6 +27,10 @@ describe "#lrange(key, start, stop)" do
     @redises.lrange("mock-redis-test:bogus-key", 0, 1).should == []
   end
 
+  it "returns [] when start is too large" do
+    @redises.lrange(@key, 100, 100).should == []
+  end
+
   it "finds the end of the list correctly when end is too large" do
     @redises.lrange(@key, 4, 10).should == %w[v4]
   end


### PR DESCRIPTION
It was returning nil when the start index was beyond the end of the list.

Let me know if this needs any additional work.

thanks,
Charles.
