### PR TITLE
Allow strings for indexes in list commands

### DIFF
--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -45,7 +45,7 @@ class MockRedis
     end
 
     def lindex(key, index)
-      with_list_at(key) {|l| l[index]}
+      with_list_at(key) {|l| l[index.to_i]}
     end
 
     def linsert(key, position, pivot, value)
@@ -93,7 +93,8 @@ class MockRedis
     end
 
     def lrange(key, start, stop)
-      with_list_at(key) {|l| start < l.size ? l[start..stop] : []}
+      start = start.to_i
+      with_list_at(key) {|l| start < l.size ? l[start..stop.to_i] : []}
     end
 
     def lrem(key, count, value)
@@ -124,6 +125,7 @@ class MockRedis
         raise Redis::CommandError, "ERR no such key"
       end
 
+      index = index.to_i
       unless (0...llen(key)).include?(index)
         raise Redis::CommandError, "ERR index out of range"
       end
@@ -134,7 +136,7 @@ class MockRedis
 
     def ltrim(key, start, stop)
       with_list_at(key) do |list|
-        list.replace(list[start..stop] || []) if list
+        list.replace(list[start.to_i..stop.to_i] || []) if list
         'OK'
       end
     end

--- a/spec/commands/lindex_spec.rb
+++ b/spec/commands/lindex_spec.rb
@@ -19,6 +19,17 @@ describe '#lindex(key, index)' do
     @redises.lindex(@key, -2).should == "10"
   end
 
+  it "gets an element from the list by its index when index is a string" do
+    @redises.lpush(@key, 20)
+    @redises.lpush(@key, 10)
+
+    @redises.lindex(@key, '0').should == "10"
+    @redises.lindex(@key, '1').should == "20"
+    @redises.lindex(@key, '-1').should == "20"
+    @redises.lindex(@key, '-2').should == "10"
+  end
+
+
   it "returns nil if the index is too large (and positive)" do
     @redises.lpush(@key, 20)
 

--- a/spec/commands/lrange_spec.rb
+++ b/spec/commands/lrange_spec.rb
@@ -15,6 +15,10 @@ describe "#lrange(key, start, stop)" do
     @redises.lrange(@key, 0, 2).should == %w[v0 v1 v2]
   end
 
+  it "returns a subset of the list when start and end are strings" do
+    @redises.lrange(@key, '0', '2').should == %w[v0 v1 v2]
+  end
+
   it "returns an empty list when start > end" do
     @redises.lrange(@key, 3, 2).should == []
   end

--- a/spec/commands/lset_spec.rb
+++ b/spec/commands/lset_spec.rb
@@ -17,6 +17,11 @@ describe "#lset(key, index, value)" do
     @redises.lindex(@key, 0).should == "newthing"
   end
 
+  it "sets the list's value at index to value when the index is a string" do
+    @redises.lset(@key, '0', "newthing")
+    @redises.lindex(@key, 0).should == "newthing"
+  end
+
   it "stringifies value" do
     @redises.lset(@key, 0, 12345)
     @redises.lindex(@key, 0).should == "12345"

--- a/spec/commands/ltrim_spec.rb
+++ b/spec/commands/ltrim_spec.rb
@@ -16,6 +16,11 @@ describe "#ltrim(key, start, stop)" do
     @redises.lrange(@key, 0, -1).should == %w[v1 v2 v3]
   end
 
+  it "trims the list when start and stop are strings" do
+    @redises.ltrim(@key, '1', '3')
+    @redises.lrange(@key, 0, -1).should == %w[v1 v2 v3]
+  end
+
   it "trims the list to include only the specified elements (negative indices)" do
     @redises.ltrim(@key, -2, -1)
     @redises.lrange(@key, 0, -1).should == %w[v3 v4]


### PR DESCRIPTION
This is two commits, one of which was already submitted in my previous pull request earlier today ("Fixed lrange to return [] when start is too large" - https://github.com/causes/mock_redis/pull/34).  You could probably ignore the first one and just take this one - if it's good.  Sorry to confuse things.

Charles.
