### PR TITLE
Fix zcount to support exclusive ranges

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -231,6 +231,7 @@ class MockRedis
     end
 
     def assert_scorey(value, message = "ERR value is not a valid float")
+      value = $1 if value.to_s.match(/\((.*)/)
       unless looks_like_float?(value)
         raise Redis::CommandError, message
       end

--- a/spec/commands/zcount_spec.rb
+++ b/spec/commands/zcount_spec.rb
@@ -25,6 +25,14 @@ describe "#zcount(key, min, max)" do
     @redises.zcount(@key, 3, "+inf").should == 2
   end
 
+  it "returns a proper count of elements using exclusive lower bound" do
+    @redises.zcount(@key, '(3', "+inf").should == 1
+  end
+
+  it "returns a proper count of elements using exclusive upper bound" do
+    @redises.zcount(@key, '-inf', "(3").should == 2
+  end
+
   it_should_behave_like "arg 1 is a score"
   it_should_behave_like "arg 2 is a score"
   it_should_behave_like "a zset-only command"


### PR DESCRIPTION
I wanted to use exclusive ranges in zcount method and found out that mock_redis did not support exclusive ranges for zcount method.

```
mock_redis.zcount('myzset', '(5', '+inf')
#=> #<Redis::CommandError: ERR min or max is not a double>
```

Thought I could help and here is a fix I did to achieve support for exclusive ranges in zcount.

Great work guys! Thanks for the awesome gem! Cheers!
