### PR TITLE
Allow a TimeClass to be set through the options

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -21,6 +21,7 @@ class MockRedis
      :timeout => 5.0,
      :password => nil,
      :db => 0,
+     :time_class => Time
   }
 
   def self.connect(*args)
@@ -34,7 +35,7 @@ class MockRedis
       TransactionWrapper.new(
         ExpireWrapper.new(
           MultiDbWrapper.new(
-              Database.new(*args)))))
+              Database.new(self, *args)))))
   end
 
   def id
@@ -58,6 +59,14 @@ class MockRedis
     self.options[:db]
   end
 
+  def now
+    self.options[:time_class].now
+  end
+
+  def time_at(timestamp)
+    self.options[:time_class].at(timestamp)
+  end
+
   def client
     self
   end
@@ -79,7 +88,7 @@ class MockRedis
   protected
 
   def _parse_options(options)
-    return {} if options.nil?
+    return DEFAULTS.dup if options.nil?
 
     defaults = DEFAULTS.dup
 

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -18,7 +18,8 @@ class MockRedis
 
     attr_reader :data, :expire_times
 
-    def initialize(*args)
+    def initialize(base, *args)
+      @base = base
       @data = {}
       @expire_times = []
     end
@@ -54,7 +55,7 @@ class MockRedis
     end
 
     def expire(key, seconds)
-      expireat(key, Time.now.to_i + seconds.to_i)
+      expireat(key, @base.now.to_i + seconds.to_i)
     end
 
     def expireat(key, timestamp)
@@ -63,7 +64,7 @@ class MockRedis
       end
 
       if exists(key)
-        set_expiration(key, Time.at(timestamp.to_i))
+        set_expiration(key, @base.time_at(timestamp.to_i))
         true
       else
         false
@@ -281,7 +282,7 @@ class MockRedis
     end
 
     def lastsave
-      Time.now.to_i
+      @base.now.to_i
     end
 
     def persist(key)
@@ -335,7 +336,7 @@ class MockRedis
 
     def ttl(key)
       if has_expiration?(key)
-        expiration(key).to_i - Time.now.to_i
+        expiration(key).to_i - @base.now.to_i
       else
         -1
       end
@@ -430,7 +431,7 @@ class MockRedis
     # This method isn't private, but it also isn't a Redis command, so
     # it doesn't belong up above with all the Redis commands.
     def expire_keys
-      now = Time.now
+      now = @base.now
 
       to_delete = expire_times.take_while do |(time, key)|
         time <= now

--- a/spec/mock_redis_spec.rb
+++ b/spec/mock_redis_spec.rb
@@ -29,4 +29,48 @@ describe MockRedis do
 
     its(:id) { should == url }
   end
+
+  describe 'Injecting a time class' do
+    describe '.options' do
+      let(:time_stub) { double 'Time' }
+      let(:options)   { { :time_class => time_stub } }
+
+      it 'defaults to Time' do
+        mock_redis = MockRedis.new
+
+        mock_redis.options[:time_class].should == Time
+      end
+
+      it 'has a configurable Time class' do
+        mock_redis = MockRedis.new(options)
+
+        mock_redis.options[:time_class].should == time_stub
+      end
+    end
+
+    describe '.now' do
+      let(:now)       { 'Now' }
+      let(:time_stub) { double 'Time', :now => now }
+      let(:options)   { { :time_class => time_stub } }
+
+      subject { MockRedis.new(options) }
+
+      its(:now) { should == now }
+    end
+
+    describe '.expireat' do
+      let(:time_at)   { 'expireat' }
+      let(:time_stub) { double 'Time' }
+      let(:options)   { { :time_class => time_stub } }
+      let(:timestamp) { 123456 }
+
+      subject { MockRedis.new(options) }
+
+      it 'Forwards time_at to the time_class' do
+        time_stub.should_receive(:at).with(timestamp).and_return(time_at)
+
+        subject.time_at(timestamp).should == time_at
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows MockRedis to work with the TimeClass the user has specified instead of assuming Time. This allows the developer to pass in any object that listens to .at(timestamp) and .now.

Allowing to take in a Time class fixes several Timing (re: Time zones and stubs) issues I was having and won't force me to stub out Time.now/.at. 
