### PR TITLE
Add '*' param default for `keys`

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -277,7 +277,7 @@ class MockRedis
       }
     end
 
-    def keys(format)
+    def keys(format = '*')
       data.keys.grep(redis_pattern_to_ruby_regex(format))
     end
 


### PR DESCRIPTION
Small thing here: it's the default in in redis-rb, so gives congruity for quick debugging checks.

https://github.com/redis/redis-rb/blob/94e0b2a7a60c152510fa8731871d11bdd898a362/lib/redis.rb#L404-L418
