### PR TITLE
* matches 0 or more characters, not 1 or more.

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -412,7 +412,7 @@ class MockRedis
       Regexp.new(
         "^#{pattern}$".
         gsub(/([^\\])\?/, "\\1.").
-        gsub(/([^\\])\*/, "\\1.+"))
+        gsub(/([^\\])\*/, "\\1.*"))
     end
 
     def remove_expiration(key)

--- a/spec/commands/keys_spec.rb
+++ b/spec/commands/keys_spec.rb
@@ -12,6 +12,7 @@ describe '#keys()' do
 
   describe "with pattern matching" do
     before do
+      @redises.set("mock-redis-test:key",   0)
       @redises.set("mock-redis-test:key1",  1)
       @redises.set("mock-redis-test:key2",  2)
       @redises.set("mock-redis-test:key3",  3)
@@ -48,8 +49,9 @@ describe '#keys()' do
     end
 
     describe "the * character" do
-      it "is treated as 1 or more characters" do
+      it "is treated as 0 or more characters" do
         @redises.keys("mock-redis-test:key*").sort.should == [
+          'mock-redis-test:key',
           'mock-redis-test:key1',
           'mock-redis-test:key10',
           'mock-redis-test:key2',


### PR DESCRIPTION
(see http://redis.io/commands/keys)
