### PR TITLE
Ensure that commands respects symbols or strings for keys

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -6,6 +6,7 @@ require 'mock_redis/set_methods'
 require 'mock_redis/string_methods'
 require 'mock_redis/zset_methods'
 require 'mock_redis/sort_method'
+require 'mock_redis/indifferent_hash'
 
 class MockRedis
   class Database
@@ -20,7 +21,7 @@ class MockRedis
 
     def initialize(base, *args)
       @base = base
-      @data = {}
+      @data = MockRedis::IndifferentHash.new
       @expire_times = []
     end
 

--- a/lib/mock_redis/indifferent_hash.rb
+++ b/lib/mock_redis/indifferent_hash.rb
@@ -1,0 +1,11 @@
+class MockRedis
+  class IndifferentHash < Hash
+    def [](key)
+      super(key.to_s)
+    end
+
+    def []=(key, value)
+      super(key.to_s, value)
+    end
+  end
+end

--- a/spec/commands/get_spec.rb
+++ b/spec/commands/get_spec.rb
@@ -19,5 +19,12 @@ describe "#get(key)" do
     @redises.get(@key).should == "100"
   end
 
+  it "stringifies key" do
+    key = :a_symbol
+
+    @redises.set(key, 'hello')
+    @redises.get(key.to_s).should == 'hello'
+  end
+
   it_should_behave_like "a string-only command"
 end


### PR DESCRIPTION
Noticed that if I did:

``` ruby
mr = MockRedis.new

mr.set :a_key, 'blah'
mr.get 'a_key' == 'blah' # false
```

This is not how the redis client behaves.
