### PR TITLE
Sorting on a non-existant range shouldn't die

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -160,7 +160,7 @@ class MockRedis
     end
 
     def to_response(score_member_pairs, options)
-      score_member_pairs.map do |(score,member)|
+      (score_member_pairs || []).map do |(score,member)|
         if options[:with_scores] || options[:withscores]
           [member, score.to_f]
         else


### PR DESCRIPTION
Hey --

I think this fixes a bug that I ran across in my local switchover.  Not sure if it is 100% compliant, but thought I'd send it your way.

If you do a zset request on a set which does not exist, I believe it should just return [].  Without this fix it throws an exception.
