### PR TITLE
Fix a bug in zrevrange

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -101,7 +101,7 @@ class MockRedis
 
     def zrevrange(key, start, stop, options={})
       with_zset_at(key) do |z|
-        to_response(z.sorted.reverse[start..stop], options)
+        to_response(z.sorted.reverse[start..stop] || [], options)
       end
     end
 

--- a/spec/commands/zrevrange_spec.rb
+++ b/spec/commands/zrevrange_spec.rb
@@ -17,6 +17,10 @@ describe "#zrevrange(key, start, stop [, :with_scores => true])" do
     @redises.zrevrange(@key, -2, -1).should == ['Adams', 'Washington']
   end
 
+  it 'returns empty list when start is too large' do
+    @redises.zrevrange(@key, 5, -1).should == []
+  end
+
   it "returns the scores when :with_scores is specified" do
     @redises.zrevrange(@key, 2, 3, :with_scores => true).
       should == [["Adams", 2.0], ["Washington", 1.0]]


### PR DESCRIPTION
 fix a bug : zrevrange should return empty list when start is too large but returns nil.
