### PR TITLE
Allow specs to run in Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source "http://rubygems.org"
 gemspec
 
 group :test do
-  gem "ruby-debug", :platforms => :mri_18
-  gem "debugger", :platforms => :mri_19
+  gem "debugger"
 end


### PR DESCRIPTION
Simple change to allow specs to run under Ruby 2.0.
