### PR TITLE
solved problems with mock_redis when used with Sinatra

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -31,6 +31,11 @@ class MockRedis
   def initialize(*args)
     @options = _parse_options(args.first)
 
+    [PipelinedWrapper, TransactionWrapper, ExpireWrapper, MultiDbWrapper].each do |wrapper|
+      wrapper.send(:undef_method, :set)
+      wrapper.send(:undef_method, :get)
+    end
+    
     @db = PipelinedWrapper.new(
       TransactionWrapper.new(
         ExpireWrapper.new(


### PR DESCRIPTION
When the sinatra gem is used, it mixes in Sinatra::Delegator for all classes. Thus set/get operations will fail with mock_redis since these calls will be handled by Sinatra and not mock_redis. This fix undefines the set/get methods and makes sure the wrapper's method_missing methods are used instead.

This way sinatra and mock_redis can co-exist and work as expected.
