### PR TITLE
Add support for HINCRBYFLOAT

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -46,6 +46,24 @@ class MockRedis
       end
     end
 
+    def hincrbyfloat(key, field, increment)
+      with_hash_at(key) do |hash|
+        field = field.to_s
+        unless can_incr_float?(data[key][field])
+          raise Redis::CommandError, "ERR hash value is not a valid float"
+        end
+
+        unless looks_like_float?(increment.to_s)
+          raise Redis::CommandError, "ERR value is not a valid float"
+        end
+
+        new_value = (hash[field] || "0").to_f + increment.to_f
+        new_value = new_value.to_i if new_value % 1 == 0
+        hash[field] = new_value.to_s
+        new_value
+      end
+    end
+
     def hkeys(key)
       with_hash_at(key, &:keys)
     end

--- a/spec/commands/hincrbyfloat_spec.rb
+++ b/spec/commands/hincrbyfloat_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe '#hincrbyfloat(key, field, increment)' do
+  before do
+    @key = 'mock-redis-test:hincrbyfloat'
+    @field = 'count'
+  end
+
+  it "returns the value after the increment" do
+    @redises.hset(@key, @field, 2.0)
+    @redises.hincrbyfloat(@key, @field, 2.1).should be_within(0.0001).of(4.1)
+  end
+
+  it "treats a missing key like 0" do
+    @redises.hincrbyfloat(@key, @field, 1.2).should be_within(0.0001).of(1.2)
+  end
+
+  it "creates a hash if nothing is present" do
+    @redises.hincrbyfloat(@key, @field, 1.0)
+    @redises.hget(@key, @field).should == "1"
+  end
+
+  it "increments negative numbers" do
+    @redises.hset(@key, @field, -10.4)
+    @redises.hincrbyfloat(@key, @field, 2.3).should be_within(0.0001).of(-8.1)
+  end
+
+  it "works multiple times" do
+    @redises.hincrbyfloat(@key, @field, 2.1).should be_within(0.0001).of(2.1)
+    @redises.hincrbyfloat(@key, @field, 2.2).should be_within(0.0001).of(4.3)
+    @redises.hincrbyfloat(@key, @field, 2.3).should be_within(0.0001).of(6.6)
+  end
+
+  it "accepts a float-ish string" do
+    @redises.hincrbyfloat(@key, @field, "2.2").should be_within(0.0001).of(2.2)
+  end
+
+  it "treats the field as a string" do
+    field = 11
+    @redises.hset(@key, field, 2)
+    @redises.hincrbyfloat(@key, field, 2).should == 4.0
+  end
+
+  it "raises an error if the value does not look like a float" do
+    @redises.hset(@key, @field, "one.two")
+    lambda do
+      @redises.hincrbyfloat(@key, @field, 1)
+    end.should raise_error(RuntimeError)
+  end
+
+  it "raises an error if the delta does not look like a float" do
+    lambda do
+      @redises.hincrbyfloat(@key, @field, "foobar.baz")
+    end.should raise_error(RuntimeError)
+  end
+
+  it_should_behave_like "a hash-only command"
+end


### PR DESCRIPTION
This commit adds HINCRBYFLOAT (available since Redis 2.6.0).
The code and specs were heavily inspired by the ones already
available for `hincrby` and `incrbyfloat`.
