### PR TITLE
Raise Errors For Empty Arrays as Arguments

### DIFF
--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -82,11 +82,16 @@ class MockRedis
 
     def lpush(key, values)
       values = [values] unless values.is_a?(Array)
+      assert_has_args(values, 'lpush')
       with_list_at(key) {|l| values.each {|v| l.unshift(v.to_s)}}
       llen(key)
     end
 
     def lpushx(key, value)
+      value = [value] unless value.is_a?(Array)
+      if value.length != 1
+        raise Redis::CommandError, "ERR wrong number of arguments for 'lpushx' command"
+      end
       assert_listy(key)
       return 0 unless list_at?(key)
       lpush(key, value)
@@ -156,11 +161,16 @@ class MockRedis
 
     def rpush(key, values)
       values = [values] unless values.is_a?(Array)
+      assert_has_args(values, 'rpush')
       with_list_at(key) {|l| values.each {|v| l.push(v.to_s)}}
       llen(key)
     end
 
     def rpushx(key, value)
+      value = [value] unless value.is_a?(Array)
+      if value.length != 1
+        raise Redis::CommandError, "ERR wrong number of arguments for 'rpushx' command"
+      end
       assert_listy(key)
       return 0 unless list_at?(key)
       rpush(key, value)

--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -8,6 +8,7 @@ class MockRedis
 
     def sadd(key, members)
       members = [members].flatten.map(&:to_s)
+      assert_has_args(members, 'sadd')
 
       with_set_at(key) do |s|
         if members.size > 1

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -10,6 +10,8 @@ class MockRedis
     def zadd(key, *args)
       if args.size == 1 && args[0].is_a?(Array)
         args = args.first
+        assert_has_args(args, 'zadd')
+
         args = args.each_slice(2).to_a unless args.first.is_a?(Array)
         retval = args.map(&:last).map { |member| !!zscore(key, member.to_s) }.count(false)
         with_zset_at(key) do |z|

--- a/spec/commands/lpush_spec.rb
+++ b/spec/commands/lpush_spec.rb
@@ -33,5 +33,11 @@ describe "#lpush(key, value)" do
     @redises.lindex(@key, 2).should == "1"
   end
 
+  it "raises an error if an empty array is given" do
+    lambda do
+      @redises.lpush(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like "a list-only command"
 end

--- a/spec/commands/lpushx_spec.rb
+++ b/spec/commands/lpushx_spec.rb
@@ -29,5 +29,17 @@ describe "#lpushx(key, value)" do
     @redises.lindex(@key, 0).should == "2"
   end
 
+  it "raises an error if an empty array is given" do
+    lambda do
+      @redises.lpushx(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
+  it "raises an error if an array of more than one item is given" do
+    lambda do
+      @redises.lpushx(@key, [1, 2])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like "a list-only command"
 end

--- a/spec/commands/rpush_spec.rb
+++ b/spec/commands/rpush_spec.rb
@@ -33,5 +33,11 @@ describe "#rpush(key)" do
     @redises.lindex(@key, 2).should == "3"
   end
 
+  it "raises an error if an empty array is given" do
+    lambda do
+      @redises.rpush(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like "a list-only command"
 end

--- a/spec/commands/rpushx_spec.rb
+++ b/spec/commands/rpushx_spec.rb
@@ -29,5 +29,17 @@ describe "#rpushx(key, value)" do
     @redises.lindex(@key, 1).should == "2"
   end
 
+  it "raises an error if an empty array is given" do
+    lambda do
+      @redises.rpushx(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
+  it "raises an error if an array of more than one item is given" do
+    lambda do
+      @redises.rpushx(@key, [1, 2])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like "a list-only command"
 end

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -35,6 +35,11 @@ describe '#sadd(key, member)' do
       @redises.smembers(@key).should == %w[1 2 3]
     end
 
+    it "raises an error if an empty array is given" do
+      lambda do
+        @redises.sadd(@key, [])
+      end.should raise_error(Redis::CommandError)
+    end
   end
 
   it_should_behave_like "a set-only command"

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -36,6 +36,12 @@ describe "#zadd(key, score, member)" do
     @redises.zrange(@key, 0, -1).should == ['one', 'two', 'three']
   end
 
+  it "raises an error if an empty array is given" do
+    lambda do
+      @redises.zadd(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like "arg 1 is a score"
   it_should_behave_like "a zset-only command"
 end


### PR DESCRIPTION
Redis will unwrap arguments passed as arrays, so [] becomes
nothing, as if you didn't pass an argument. This means it will raise
"ERR wrong number of arguments for ':command'" errors when an empty
array is passed to something that accepts a variable number of
arguments (eg 'lpush'). Also, for lpushx and rpushx you can only pass
one value, so it will throw that same error if you try to pass an
array of multiple items.

I added handlers for the cases mentioned above, along with
corresponding tests. The commands I updated are: lpush, lpushx,
rpush, rpushx, sadd, zadd. I don't believe this is an exhaustive list
of commands where this error pops up, but these seem to be the most
common ones.
