### PR TITLE
Raise on empty array given to `del`

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -54,8 +54,10 @@ class MockRedis
     end
 
     def del(*keys)
+      keys = keys.flatten.map(&:to_s)
+      assert_has_args(keys, 'del')
+
       keys.
-        flatten.
         find_all{|key| data[key]}.
         each {|k| persist(k)}.
         each {|k| data.delete(k)}.

--- a/spec/commands/del_spec.rb
+++ b/spec/commands/del_spec.rb
@@ -27,4 +27,9 @@ describe '#del(key [, key, ...])' do
     @redises.get('mock-redis-test:1').should be_nil
     @redises.get('mock-redis-test:2').should be_nil
   end
+
+  it "raises an error if an empty array is given" do
+    expect { @redises.del [] }.to raise_error Redis::CommandError
+  end
 end
+


### PR DESCRIPTION
Following from #74, DEL should get the same treatment:

MockRedis:

``` ruby
$mock_redis.del []  # => 0
```

redis-rb:

``` ruby
$redis.del []  # => Redis::CommandError
```
