### PR TITLE
add ability to unset bit

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -199,7 +199,7 @@ class MockRedis
       char_as_number = char.each_byte.reduce(0) do |a, byte|
         (a << 8) + byte
       end
-      char_as_number |=
+      char_as_number ^=
         (2**((char.bytesize * 8)-1) >>
         (offset_within_char * 8 + offset_within_byte))
       str[char_index] = char_as_number.chr

--- a/spec/commands/setbit_spec.rb
+++ b/spec/commands/setbit_spec.rb
@@ -19,6 +19,13 @@ describe "#setbit(key, offset)" do
     @redises.get(@key).should == 'i'  # ASCII 0x69
   end
 
+  it "unsets the bit within the string" do
+    $debug = true
+    @redises.setbit(@key, 1, 0)
+    $debug = false
+    @redises.get(@key).should == '('  # ASCII 0x28
+  end
+
   it "does the right thing with multibyte characters" do
     @redises.set(@key, "€99.94")   # the euro sign is 3 bytes wide in UTF-8
     @redises.setbit(@key, 63, 1).should == 0


### PR DESCRIPTION
Currently setbit only allows setting a bit to 1 but not the other way around. OR bitwise operation was changed to XOR to support this.
