### PR TITLE
Add #connect method

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -71,6 +71,10 @@ class MockRedis
     self
   end
 
+  def connect
+    self
+  end
+
   def reconnect
     self
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,4 +7,11 @@ describe 'client' do
       redis.reconnect.should == redis
     end
   end
+
+  context '#connect' do
+    it 'connects' do
+      redis = MockRedis.new
+      redis.connect.should == redis
+    end
+  end
 end


### PR DESCRIPTION
This makes this code, found occasionally in unicorn configs, work even in mock mode:

```
  $redis.client.connect if $redis.try( :client )
```
