### PR TITLE
Update blocking list commands to be compatible with redis-rb >= 3.0.0

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -210,8 +210,8 @@ class MockRedis
     private
 
     def assert_valid_timeout(timeout)
-      if !looks_like_float?(timeout.to_s)
-        raise Redis::CommandError, "ERR timeout is not a float or out of range"
+      if !looks_like_integer?(timeout.to_s)
+        raise Redis::CommandError, "ERR timeout is not an integer or out of range"
       elsif timeout < 0
         raise Redis::CommandError, "ERR timeout is negative"
       end
@@ -227,8 +227,13 @@ class MockRedis
     end
 
     def extract_timeout(arglist)
-      timeout = assert_valid_timeout(arglist.last)
-      [arglist[0..-2], arglist.last]
+      options = arglist.last
+      if options.is_a?(Hash) && options[:timeout]
+        timeout = assert_valid_timeout(options[:timeout])
+        [arglist[0..-2], timeout]
+      else
+        [arglist, 0]
+      end
     end
 
     def expiration(key)

--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -32,7 +32,8 @@ class MockRedis
       end
     end
 
-    def brpoplpush(source, destination, timeout)
+    def brpoplpush(source, destination, options = {})
+      timeout = options.is_a?(Hash) && options[:timeout] || 0
       assert_valid_timeout(timeout)
 
       if llen(source) > 0

--- a/spec/commands/blpop_spec.rb
+++ b/spec/commands/blpop_spec.rb
@@ -12,30 +12,30 @@ describe '#blpop(key [, key, ...,], timeout)' do
   end
 
   it "returns [first-nonempty-list, popped-value]" do
-    @redises.blpop(@list1, @list2, 1).should == [@list1, 'one']
+    @redises.blpop(@list1, @list2).should == [@list1, 'one']
   end
 
   it "pops that value off the list" do
-    @redises.blpop(@list1, @list2, 1)
-    @redises.blpop(@list1, @list2, 1)
+    @redises.blpop(@list1, @list2)
+    @redises.blpop(@list1, @list2)
 
-    @redises.blpop(@list1, @list2, 1).should == [@list2, 'ten']
+    @redises.blpop(@list1, @list2).should == [@list2, 'ten']
   end
 
   it "ignores empty keys" do
-    @redises.blpop('mock-redis-test:not-here', @list1, 1).should ==
+    @redises.blpop('mock-redis-test:not-here', @list1).should ==
       [@list1, 'one']
   end
 
-  it "allows subsecond timeouts" do
+  it "raises an error on subsecond timeouts" do
     lambda do
-      @redises.blpop(@list1, @list2, 0.5)
-    end.should_not raise_error
+      @redises.blpop(@list1, @list2, :timeout => 0.5)
+    end.should raise_error(Redis::CommandError)
   end
 
   it "raises an error on negative timeout" do
     lambda do
-      @redises.blpop(@list1, @list2, -1)
+      @redises.blpop(@list1, @list2, :timeout => -1)
     end.should raise_error(Redis::CommandError)
   end
 
@@ -43,12 +43,12 @@ describe '#blpop(key [, key, ...,], timeout)' do
 
   context "[mock only]" do
     it "ignores positive timeouts and returns nil" do
-      @redises.mock.blpop('mock-redis-test:not-here', 1).should be_nil
+      @redises.mock.blpop('mock-redis-test:not-here', :timeout => 1).should be_nil
     end
 
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
-        @redises.mock.blpop('mock-redis-test:not-here', 0)
+        @redises.mock.blpop('mock-redis-test:not-here', :timeout => 0)
       end.should raise_error(MockRedis::WouldBlock)
     end
   end

--- a/spec/commands/brpop_spec.rb
+++ b/spec/commands/brpop_spec.rb
@@ -12,29 +12,29 @@ describe '#brpop(key [, key, ...,], timeout)' do
   end
 
   it "returns [first-nonempty-list, popped-value]" do
-    @redises.brpop(@list1, @list2, 1).should == [@list1, 'two']
+    @redises.brpop(@list1, @list2).should == [@list1, 'two']
   end
 
   it "pops that value off the list" do
-    @redises.brpop(@list1, @list2, 1)
-    @redises.brpop(@list1, @list2, 1)
-    @redises.brpop(@list1, @list2, 1).should == [@list2, 'ten']
+    @redises.brpop(@list1, @list2)
+    @redises.brpop(@list1, @list2)
+    @redises.brpop(@list1, @list2).should == [@list2, 'ten']
   end
 
   it "ignores empty keys" do
-    @redises.brpop('mock-redis-test:not-here', @list1, 1).should ==
+    @redises.brpop('mock-redis-test:not-here', @list1).should ==
       [@list1, 'two']
   end
 
-  it "allows subsecond timeouts" do
+  it "raises an error on subsecond timeouts" do
     lambda do
-      @redises.brpop(@list1, @list2, 0.5)
-    end.should_not raise_error
+      @redises.brpop(@list1, @list2, :timeout => 0.5)
+    end.should raise_error(Redis::CommandError)
   end
 
   it "raises an error on negative timeout" do
     lambda do
-      @redises.brpop(@list1, @list2, -1)
+      @redises.brpop(@list1, @list2, :timeout => -1)
     end.should raise_error(Redis::CommandError)
   end
 
@@ -42,12 +42,12 @@ describe '#brpop(key [, key, ...,], timeout)' do
 
   context "[mock only]" do
     it "ignores positive timeouts and returns nil" do
-      @redises.mock.brpop('mock-redis-test:not-here', 1).should be_nil
+      @redises.mock.brpop('mock-redis-test:not-here', :timeout => 1).should be_nil
     end
 
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
-        @redises.mock.brpop('mock-redis-test:not-here', 0)
+        @redises.mock.brpop('mock-redis-test:not-here', :timeout => 0)
       end.should raise_error(MockRedis::WouldBlock)
     end
   end

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -15,18 +15,18 @@ describe '#brpoplpush(source, destination, timeout)' do
   end
 
   it "takes the last element of source and prepends it to destination" do
-    @redises.brpoplpush(@list1, @list2, 0)
+    @redises.brpoplpush(@list1, @list2)
     @redises.lrange(@list1, 0, -1).should == %w[A]
     @redises.lrange(@list2, 0, -1).should == %w[B alpha beta]
   end
 
   it "returns the moved element" do
-    @redises.brpoplpush(@list1, @list2, 0).should == "B"
+    @redises.brpoplpush(@list1, @list2).should == "B"
   end
 
   it "raises an error on negative timeout" do
     lambda do
-      @redises.brpoplpush(@list1, @list2, -1)
+      @redises.brpoplpush(@list1, @list2, :timeout => -1)
     end.should raise_error(Redis::CommandError)
   end
 
@@ -34,13 +34,13 @@ describe '#brpoplpush(source, destination, timeout)' do
 
   context "[mock only]" do
     it "ignores positive timeouts and returns nil" do
-      @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1).
+      @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 1).
         should be_nil
     end
 
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
-        @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 0)
+        @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 0)
       end.should raise_error(MockRedis::WouldBlock)
     end
   end


### PR DESCRIPTION
redis-rb >= 3.0.0 uses an options hash to set the timeout for blocking list commands. Also, the timeout must now be a Fixnum. These changes should make MockRedis compatible.
