### PR TITLE
add support for legacy-style timeouts on blocking list commands

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -231,6 +231,9 @@ class MockRedis
       if options.is_a?(Hash) && options[:timeout]
         timeout = assert_valid_timeout(options[:timeout])
         [arglist[0..-2], timeout]
+      elsif options.kind_of?(Integer)
+        timeout = assert_valid_timeout(options)
+        [arglist[0..-2], timeout]
       else
         [arglist, 0]
       end

--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -33,6 +33,7 @@ class MockRedis
     end
 
     def brpoplpush(source, destination, options = {})
+      options = { :timeout => options } if options.kind_of?(Integer)
       timeout = options.is_a?(Hash) && options[:timeout] || 0
       assert_valid_timeout(timeout)
 

--- a/spec/commands/blpop_spec.rb
+++ b/spec/commands/blpop_spec.rb
@@ -46,6 +46,10 @@ describe '#blpop(key [, key, ...,], timeout)' do
       @redises.mock.blpop('mock-redis-test:not-here', :timeout => 1).should be_nil
     end
 
+    it "ignores positive legacy timeouts and returns nil" do
+      @redises.mock.blpop('mock-redis-test:not-here', 1).should be_nil
+    end
+
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
         @redises.mock.blpop('mock-redis-test:not-here', :timeout => 0)

--- a/spec/commands/brpop_spec.rb
+++ b/spec/commands/brpop_spec.rb
@@ -45,6 +45,10 @@ describe '#brpop(key [, key, ...,], timeout)' do
       @redises.mock.brpop('mock-redis-test:not-here', :timeout => 1).should be_nil
     end
 
+    it "ignores positive legacy timeouts and returns nil" do
+      @redises.mock.brpop('mock-redis-test:not-here', 1).should be_nil
+    end
+
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
         @redises.mock.brpop('mock-redis-test:not-here', :timeout => 0)

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -38,6 +38,11 @@ describe '#brpoplpush(source, destination, timeout)' do
         should be_nil
     end
 
+    it "ignores positive legacy timeouts and returns nil" do
+      @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1).
+        should be_nil
+    end
+
     it "raises WouldBlock on zero timeout (no blocking in the mock)" do
       lambda do
         @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 0)


### PR DESCRIPTION
The redis-rb gem 3.x still supports 2.x-style timeout arguments, so
we should too. This ensures that if the timeout is specified as an integer,
instead of a {timeout: Integer} hash, it is still recognized as a timeout.

[Resque](https://github.com/resque/resque) still uses the legacy timeout method signature, and the 0.13.0 release broke our build; we have since pinned to 0.12.x, but this is an attempt to get us back onto the current release.
