### PR TITLE
smembers: don't return frozen elements

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -59,7 +59,7 @@ class MockRedis
     end
 
     def smembers(key)
-      with_set_at(key, &:to_a).reverse
+      with_set_at(key, &:to_a).map(&:dup).reverse
     end
 
     def smove(src, dest, member)

--- a/spec/commands/smembers_spec.rb
+++ b/spec/commands/smembers_spec.rb
@@ -14,5 +14,15 @@ describe '#smembers(key)' do
     @redises.smembers(@key).should == %w[Test World Hello]
   end
 
+  it 'returns unfrozen copies of the input' do
+    input = 'a string'
+    @redises.sadd(@key, input)
+    output = @redises.smembers(@key).first
+
+    expect(output).to eq input
+    expect(output).to_not equal input
+    expect(output).to_not be_frozen
+  end
+
   it_should_behave_like "a set-only command"
 end


### PR DESCRIPTION
Since `redis-rb` doesn't return frozen elements here, neither should we.
