### PR TITLE
Fix Database#expire_keys when more than one expiration

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -296,8 +296,6 @@ class MockRedis
       to_delete.each do |(time, key)|
         del(key)
       end
-
-      expire_times.slice!(0, to_delete.length)
     end
   end
 end

--- a/spec/commands/expire_spec.rb
+++ b/spec/commands/expire_spec.rb
@@ -91,5 +91,21 @@ describe "#expire(key, seconds)" do
       end
     end
 
+    context 'with two key expirations' do
+      let(:other_key) { 'mock-redis-test:expire-other' }
+
+      before { @redises.set(other_key, 'spork-other') }
+
+      it 'removes keys after enough time has passed' do
+        @mock.expire(@key, 5)
+        @mock.expire(other_key, 10)
+
+        Time.stub(:now).and_return(@now + 5)
+        @mock.get(@key).should be_nil
+
+        Time.stub(:now).and_return(@now + 10)
+        @mock.get(other_key).should be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
expire_times array is already cleaned by #del(key). We dont need to remove items in #expire_keys.

The `expire_times.slice!` is removing other pairs which are not suposed to expire yet.
