### PR TITLE
Allow set methods to take an Array as argument in addition to String arguments

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -127,6 +127,7 @@ class MockRedis
     end
 
     def with_sets_at(*keys, &blk)
+      keys = keys.flatten
       if keys.length == 1
         with_set_at(keys.first, &blk)
       else

--- a/spec/commands/sunion_spec.rb
+++ b/spec/commands/sunion_spec.rb
@@ -18,6 +18,10 @@ describe '#sunion(key [, key, ...])' do
       should == %w[2 3 5 7]
   end
 
+  it "allows Array as argument" do
+    @redises.sunion([@evens, @primes]).should == %w[2 4 6 8 10 3 5 7]
+  end
+
   it "raises an error if given 0 sets" do
     lambda do
       @redises.sunion


### PR DESCRIPTION
The Redis gem allows keys to be passed to set methods as an Array. Both of these calls return the same value:

```
sunion(['a', 'b'])
sunion('a', 'b')
```

This pull requests allows MockRedis to function in the same manner.
