### PR TITLE
Fix SET method for other options coming from Redis::Store

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -220,15 +220,22 @@ class MockRedis
       end
       data[key] = value.to_s
 
-      # take latter
-      expire_option = options.to_a.last
-      if expire_option
-        type, duration = expire_option
+      duration = options.delete(:ex)
+      if duration
         if duration == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        expire(key, type.to_sym == :ex ? duration : duration / 1000.0)
+        expire(key, duration)
       end
+
+      duration = options.delete(:px)
+      if duration
+        if duration == 0
+          raise Redis::CommandError, 'ERR invalid expire time in set'
+        end
+        expire(key, duration / 1000.0)
+      end
+
       return_true ? true : 'OK'
     end
 

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -33,6 +33,12 @@ describe '#set(key, value)' do
       @redises.set(key, 1, xx: true).should == true
     end
 
+    it 'ignores other options' do
+      key = 'mock-redis-test'
+      @redises.del(key)
+      @redises.set(key, 1, logger: :something).should == 'OK'
+    end
+
     context '[mock only]' do
       before(:all) do
         @mock = @redises.mock


### PR DESCRIPTION
`ActiveSupport::Cache::RedisStore` passes all options into methods. `Redis` ignores options that it doesn't need. But `MockRedis` expects ex/px as the last key in `options`. 

Example:
```
MockRedis.new.set(:test, '1', logger: Logger.new(STDOUT))
=> NoMethodError: undefined method `/' for #<Logger:0x00007fe1a7a74ca8>
```