### PR TITLE
Fix srem to allow passing an array of integers as argument

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -117,6 +117,7 @@ class MockRedis
       with_set_at(key) do |s|
         if members.is_a?(Array)
           orig_size = s.size
+          members = members.map(&:to_s)
           s.delete_if { |m| members.include?(m) }
           orig_size - s.size
         else

--- a/spec/commands/srem_spec.rb
+++ b/spec/commands/srem_spec.rb
@@ -36,5 +36,10 @@ describe '#srem(key, member)' do
     @redises.get(@key).should be_nil
   end
 
+  it 'allow passing an array of integers as argument' do
+    @redises.sadd(@key, %w[1 2])
+    @redises.srem(@key, [1, 2]).should == 2
+  end
+
   it_should_behave_like 'a set-only command'
 end


### PR DESCRIPTION
Related to this issue: https://github.com/sds/mock_redis/issues/165

`MockRedis#srem` currently dos not support passing an array of integers as argument, this PR fixes it.