### PR TITLE
Fix inconsistent behavior between `Redis#hdel`, `MockRedis#hdel`

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -8,14 +8,10 @@ class MockRedis
 
     def hdel(key, *fields)
       with_hash_at(key) do |hash|
-        if fields.is_a?(Array)
-          orig_size = hash.size
-          fields    = fields.map(&:to_s)
-          hash.delete_if { |k, _v| fields.include?(k) }
-          orig_size - hash.size
-        else
-          hash.delete(fields[0].to_s) ? 1 : 0
-        end
+        orig_size = hash.size
+        fields = Array(fields).flatten.map(&:to_s)
+        hash.delete_if { |k, _v| fields.include?(k) }
+        orig_size - hash.size
       end
     end
 

--- a/spec/commands/hdel_spec.rb
+++ b/spec/commands/hdel_spec.rb
@@ -50,5 +50,21 @@ describe '#hdel(key, field)' do
     @redises.hget(@key, field).should be_nil
   end
 
+  it 'supports a variable number of fields as array' do
+    @redises.hdel(@key, %w[k1 k2]).should == 2
+
+    @redises.hget(@key, 'k1').should be_nil
+    @redises.hget(@key, 'k2').should be_nil
+    @redises.get(@key).should be_nil
+  end
+
+  it 'supports a list of fields in various way' do
+    @redises.hdel(@key, ['k1'], 'k2').should == 2
+
+    @redises.hget(@key, 'k1').should be_nil
+    @redises.hget(@key, 'k2').should be_nil
+    @redises.get(@key).should be_nil
+  end
+
   it_should_behave_like 'a hash-only command'
 end


### PR DESCRIPTION
Close #167 

`hdel` now accepts hash keys in various way:

```ruby
  redis.hdel('test-hash', 'key1', 'key2')
  redis.hdel('test-hash', ['key1', 'key2'])
  redis.hdel('test-hash', ['key1'], 'key2')
```