### PR TITLE
Allow UtilityMethods#common_scan to receive exceeding cursor

### DIFF
--- a/lib/mock_redis/utility_methods.rb
+++ b/lib/mock_redis/utility_methods.rb
@@ -28,12 +28,15 @@ class MockRedis
       cursor = cursor.to_i
       match = opts[:match] || '*'
       key = opts[:key] || lambda { |x| x }
+      filtered_values = []
 
       limit = cursor + count
       next_cursor = limit >= values.length ? '0' : limit.to_s
 
-      filtered_values = values[cursor...limit].select do |val|
-        redis_pattern_to_ruby_regex(match).match(key.call(val))
+      unless values[cursor...limit].nil?
+        filtered_values = values[cursor...limit].select do |val|
+          redis_pattern_to_ruby_regex(match).match(key.call(val))
+        end
       end
 
       [next_cursor, filtered_values]

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -42,6 +42,15 @@ describe '#scan' do
       end
     end
 
+    context 'when cursor is greater than collection size' do
+      let(:collection) { Array.new(count) { |i| "mock:key#{i}" } }
+      let(:expected) { ['0', []] }
+
+      it 'returns a 0 cursor and empty collection' do
+        expect(subject.scan(20, count: count, match: match)).to eq(expected)
+      end
+    end
+
     context 'when giving a custom match filter' do
       let(:match) { 'mock:key*' }
       let(:collection) { %w[mock:key mock:key2 mock:otherkey] }


### PR DESCRIPTION
This is for cases when block is provided with deletion:
```
redis = MockRedis.new
11.times { |x| redis.set("state:123#{x}", x) }
redis.scan_each(match: "state:123*") do |key|
  redis.del(key)
end
```