### PR TITLE
Add zpopmin and zpopmax commands

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -155,20 +155,20 @@ class MockRedis
       retval
     end
 
-    def zpopmin(key, count=1)
+    def zpopmin(key, count = 1)
       with_zset_at(key) do |z|
         pairs = z.sorted.first(count)
         pairs.each { |pair| z.delete?(pair.last) }
-        retval = to_response(pairs, { with_scores: true })
+        retval = to_response(pairs, with_scores: true)
         count == 1 ? retval.first : retval
       end
     end
 
-    def zpopmax(key, count=1)
+    def zpopmax(key, count = 1)
       with_zset_at(key) do |z|
         pairs = z.sorted.reverse.first(count)
         pairs.each { |pair| z.delete?(pair.last) }
-        retval = to_response(pairs, { with_scores: true })
+        retval = to_response(pairs, with_scores: true)
         count == 1 ? retval.first : retval
       end
     end

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -155,6 +155,24 @@ class MockRedis
       retval
     end
 
+    def zpopmin(key, count=1)
+      with_zset_at(key) do |z|
+        pairs = z.sorted.first(count)
+        pairs.each { |pair| z.delete?(pair.last) }
+        retval = to_response(pairs, { with_scores: true })
+        count == 1 ? retval.first : retval
+      end
+    end
+
+    def zpopmax(key, count=1)
+      with_zset_at(key) do |z|
+        pairs = z.sorted.reverse.first(count)
+        pairs.each { |pair| z.delete?(pair.last) }
+        retval = to_response(pairs, { with_scores: true })
+        count == 1 ? retval.first : retval
+      end
+    end
+
     def zrevrange(key, start, stop, options = {})
       with_zset_at(key) do |z|
         to_response(z.sorted.reverse[start..stop] || [], options)

--- a/spec/commands/zpopmax_spec.rb
+++ b/spec/commands/zpopmax_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe '#zpopmin(key, count)' do
+describe '#zpopmax(key, count)' do
   before(:each) do
-    @key = 'mock-redis-test:zpopmin'
+    @key = 'mock-redis-test:zpopmax'
     @redises.del(@key)
     @redises.zadd(@key, 1, 'one')
     @redises.zadd(@key, 2, 'two')
@@ -11,11 +11,11 @@ describe '#zpopmin(key, count)' do
 
   context 'when count is unspecified' do
     it 'returns nil if the set does not exist' do
-      @redises.zpopmin('does-not-exist').should nil
+      @redises.zpopmax('does-not-exist').should nil
     end
 
-    it 'returns the lowest ranked element' do
-      @redises.zpopmin(@key).should == ['one', 1]
+    it 'returns the highest ranked element' do
+      @redises.zpopmax(@key).should == ['three', 3]
       @redises.zcard(@key).should == 2
     end
   end
@@ -24,11 +24,11 @@ describe '#zpopmin(key, count)' do
     let(:count) { 1 }
 
     it 'returns nil if the set does not exist' do
-      @redises.zpopmin('does-not-exist', count).should nil
+      @redises.zpopmax('does-not-exist', count).should nil
     end
 
-    it 'returns the lowest ranked element' do
-      @redises.zpopmin(@key, count).should == ['one', 1]
+    it 'returns the highest ranked element' do
+      @redises.zpopmax(@key, count).should == ['three', 3]
       @redises.zcard(@key).should == 2
     end
   end
@@ -37,11 +37,11 @@ describe '#zpopmin(key, count)' do
     let(:count) { 2 }
 
     it 'returns empty array if the set does not exist' do
-      @redises.zpopmin('does-not-exist', count).should == []
+      @redises.zpopmax('does-not-exist', count).should == []
     end
 
-    it 'returns the lowest ranked elements' do
-      @redises.zpopmin(@key, count).should == [['one', 1], ['two', 2]]
+    it 'returns the highest ranked elements' do
+      @redises.zpopmax(@key, count).should == [['three', 3], ['two', 2]]
       @redises.zcard(@key).should == 1
     end
   end
@@ -50,8 +50,8 @@ describe '#zpopmin(key, count)' do
     let(:count) { 4 }
 
     it 'returns the entire set' do
-      before = @redises.zrange(@key, 0, count, with_scores: true)
-      @redises.zpopmin(@key,count).should == before
+      before = @redises.zrange(@key, 0, count, with_scores: true).reverse
+      @redises.zpopmax(@key,count).should == before
       @redises.zcard(@key).should == 0
     end
   end

--- a/spec/commands/zpopmax_spec.rb
+++ b/spec/commands/zpopmax_spec.rb
@@ -51,7 +51,7 @@ describe '#zpopmax(key, count)' do
 
     it 'returns the entire set' do
       before = @redises.zrange(@key, 0, count, with_scores: true).reverse
-      @redises.zpopmax(@key,count).should == before
+      @redises.zpopmax(@key, count).should == before
       @redises.zcard(@key).should == 0
     end
   end

--- a/spec/commands/zpopmin_spec.rb
+++ b/spec/commands/zpopmin_spec.rb
@@ -51,7 +51,7 @@ describe '#zpopmin(key, count)' do
 
     it 'returns the entire set' do
       before = @redises.zrange(@key, 0, count, with_scores: true)
-      @redises.zpopmin(@key,count).should == before
+      @redises.zpopmin(@key, count).should == before
       @redises.zcard(@key).should == 0
     end
   end

--- a/spec/commands/zpopmin_spec.rb
+++ b/spec/commands/zpopmin_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'pry'
+
+describe '#zpopmin(key, count)' do
+  before(:each) do
+    @key = 'mock-redis-test:zpopmin'
+    @redises.del(@key)
+    @redises.zadd(@key, 1, 'one')
+    @redises.zadd(@key, 2, 'two')
+    @redises.zadd(@key, 3, 'three')
+  end
+
+  context 'when count is unspecified' do
+    it 'returns nil if the set does not exist' do
+      @redises.zpopmin('does-not-exist').should nil
+    end
+
+    it 'returns the lowest ranked element' do
+      @redises.zpopmin(@key).should == ['one', 1]
+      @redises.zcard(@key).should == 2
+    end
+  end
+
+  context 'when count is 1' do
+    let(:count) { 1 }
+
+    it 'returns nil if the set does not exist' do
+      @redises.zpopmin('does-not-exist', count).should nil
+    end
+
+    it 'returns the lowest ranked element' do
+      @redises.zpopmin(@key, count).should == ['one', 1]
+      @redises.zcard(@key).should == 2
+    end
+  end
+
+  context 'when count is greater than 1' do
+    let(:count) { 2 }
+
+    it 'returns empty array if the set does not exist' do
+      @redises.zpopmin('does-not-exist', count).should == []
+    end
+
+    it 'returns the lowest ranked elements' do
+      @redises.zpopmin(@key, count).should == [['one', 1], ['two', 2]]
+      @redises.zcard(@key).should == 1
+    end
+  end
+
+  context 'when count is greater than the size of the set' do
+    let(:count) { 4 }
+
+    it 'returns the entire set' do
+      before = @redises.zrange(@key, 0, count, with_scores: true)
+      @redises.zpopmin(@key,count).should == before
+      @redises.zcard(@key).should == 0
+    end
+  end
+
+  it_should_behave_like 'a zset-only command'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ module TypeCheckingHelper
   end
 
   def args_for_method(method)
-    return [] if ['spop', 'zpopmin', 'zpopmax'].include?(method.to_s)
+    return [] if %w[spop zpopmin zpopmax].include?(method.to_s)
     method_arity = @redises.real.method(method).arity
     if method_arity < 0 # -1 comes from def foo(*args)
       [1, 2] # probably good enough

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ module TypeCheckingHelper
   end
 
   def args_for_method(method)
-    return [] if method.to_s == 'spop'
+    return [] if ['spop', 'zpopmin', 'zpopmax'].include?(method.to_s)
     method_arity = @redises.real.method(method).arity
     if method_arity < 0 # -1 comes from def foo(*args)
       [1, 2] # probably good enough


### PR DESCRIPTION
redis-rb 4.1.0 introduced [zpopmin](https://redis.io/commands/zpopmin) and [zpopmax](https://redis.io/commands/zpopmax) commands.

Thoughts on adding them to this library as well? Took a first stab at it with some tests. Please let me know. Thanks!

