### PR TITLE
Raise Redis::CommandError error when setex called with a negative timeout

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -313,9 +313,13 @@ class MockRedis
     end
 
     def setex(key, seconds, value)
-      set(key, value)
-      expire(key, seconds)
-      'OK'
+      if seconds <= 0
+        raise Redis::CommandError, 'ERR invalid expire time in setex'
+      else
+        set(key, value)
+        expire(key, seconds)
+        'OK'
+      end
     end
 
     def setnx(key, value)

--- a/spec/commands/setex_spec.rb
+++ b/spec/commands/setex_spec.rb
@@ -19,4 +19,20 @@ describe '#setex(key, seconds, value)' do
     @redises.real.ttl(@key).should > 0
     @redises.mock.ttl(@key).should > 0
   end
+
+  context 'when expiration time is zero' do
+    it 'raises Redis::CommandError' do
+      expect do
+        @redises.setex(@key, 0, 'value')
+      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in setex')
+    end
+  end
+
+  context 'when expiration time is negative' do
+    it 'raises Redis::CommandError' do
+      expect do
+        @redises.setex(@key, -2, 'value')
+      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in setex')
+    end
+  end
 end


### PR DESCRIPTION
Before: 

```ruby
[7] pry(main)> MockRedis.new.setex "key", 0, "value"
=> "OK"
[8] pry(main)> Redis.new.setex "key", 0, "value"
Redis::CommandError: ERR invalid expire time in setex
```