### PR TITLE
Support returning time in pipelines

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -64,13 +64,6 @@ class MockRedis
     options[:db]
   end
 
-  def now
-    current_time = options[:time_class].now
-    miliseconds = (current_time.to_r - current_time.to_i) * 1_000
-    [current_time.to_i, miliseconds.to_i]
-  end
-  alias time now
-
   def time_at(timestamp)
     options[:time_class].at(timestamp)
   end

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -159,7 +159,7 @@ class MockRedis
     end
 
     def lastsave
-      @base.now.first
+      now.first
     end
 
     def persist(key)
@@ -239,6 +239,13 @@ class MockRedis
         -1
       end
     end
+
+    def now
+      current_time = @base.options[:time_class].now
+      miliseconds = (current_time.to_r - current_time.to_i) * 1_000
+      [current_time.to_i, miliseconds.to_i]
+    end
+    alias time now
 
     def type(key)
       if !exists(key)
@@ -344,7 +351,7 @@ class MockRedis
     # This method isn't private, but it also isn't a Redis command, so
     # it doesn't belong up above with all the Redis commands.
     def expire_keys
-      now, miliseconds = @base.now
+      now, miliseconds = self.now
       now_ms = now * 1_000 + miliseconds
 
       to_delete = expire_times.take_while do |(time, _key)|

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -66,6 +66,26 @@ describe '#pipelined' do
     end
   end
 
+  context 'with redis time return value' do
+    let(:time_stub) { double 'Time', :now => Time.new(2019, 1, 2, 3, 4, 6, '+00:00') }
+    let(:options)   { { :time_class => time_stub } }
+
+    subject { MockRedis.new(options) }
+
+    it 'returns the time value' do
+      subject.set('foo', 'bar')
+
+      results = subject.pipelined do
+        subject.get('foo')
+        subject.host # defined on MockRedis, so not captured
+        subject.time
+        subject.echo('baz')
+      end
+
+      expect(results).to eq(['bar', [1_546_398_246, 0], 'baz'])
+    end
+  end
+
   context 'with nested pipelines' do
     let(:key1)   { 'hello' }
     let(:key2)   { 'world' }


### PR DESCRIPTION
Because `now` is defined on the `MockRedis` instance itself, it isn't captured in a "future" when capturing the pipelined block.

Before this change, the added test would return `['bar', 'baz']`, instead of `['bar', [1_546_398_246, 0], 'baz']`.

Moving `now` from `MockRedis` to `Database` was the simplest way to make this work given how the current futures implementation wraps around a database, which makes it cumbersome / non-idiomatic to capture data returned by the server itself.

I'm open to suggestions how we can make this more generic (i.e. any method on the server itself is captured, and we don't have to move this method to the database layer), without creating too much coupling between the different parts of the system (I don't think we want to start monkey patching the server within a pipelined scope?).