### PR TITLE
fix: correctly set milliseconds ttl for set with px

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -233,7 +233,7 @@ class MockRedis
         if duration == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        expire(key, duration / 1000.0)
+        pexpire(key, duration)
       end
 
       return_true ? true : 'OK'

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -59,9 +59,11 @@ describe '#set(key, value)' do
 
       it 'accepts PX milliseconds' do
         key = 'mock-redis-test'
-        @mock.set(key, 1, px: 1000).should == 'OK'
+        @mock.set(key, 1, px: 500).should == 'OK'
         @mock.get(key).should_not be_nil
-        Time.stub(:now).and_return(@now + 2)
+        Time.stub(:now).and_return(@now + 300 / 1000.to_f)
+        @mock.get(key).should_not be_nil
+        Time.stub(:now).and_return(@now + 600 / 1000.to_f)
         @mock.get(key).should be_nil
       end
     end


### PR DESCRIPTION
Because `expire` calls `to_i` on the provided value, any millisecond precision is lost when a floating-point value is passed in.

The `px` duration in `set` is already supplied as an integer representing milliseconds, so we can pass it straight to `pexpire`.

The test didn't catch this mistake because it was using exact seconds in its test.