### PR TITLE
feat: support executing proc with evalsha

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -23,6 +23,7 @@ class MockRedis
     :password => nil,
     :db => 0,
     :time_class => Time,
+    :evalsha => proc {},
   }.freeze
 
   def self.connect(*args)

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -260,7 +260,9 @@ class MockRedis
 
     def script(subcommand, *args); end
 
-    def evalsha(*args); end
+    def evalsha(*args)
+      @base.options[:evalsha].call(@base, args)
+    end
 
     def eval(*args); end
 

--- a/spec/commands/evalsha_spec.rb
+++ b/spec/commands/evalsha_spec.rb
@@ -7,4 +7,14 @@ describe '#evalsha(*)' do
   it 'returns nothing' do
     @redises.evalsha(script_digest).should be_nil
   end
+
+  context 'with "evalsha" config' do
+    it 'executes the proc' do
+      block = proc { |redis, args| redis.set(args[0], args[1]) }
+      mock = MockRedis.new(evalsha: block)
+
+      mock.evalsha('foo', 'bar')
+      mock.get('foo').should == 'bar'
+    end
+  end
 end


### PR DESCRIPTION
I had the need to mimic a LUA script executed by an external library in my tests.

By passing in a block to `MockRedis`, I could make sure the external library got the result it expected, even though the actual LUA code itself isn't executed.