### PR TITLE
Raise error if passing empty array to mget

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -154,9 +154,10 @@ class MockRedis
     end
 
     def mget(*keys)
+      keys.flatten!
+
       assert_has_args(keys, 'mget')
 
-      keys.flatten!
       keys.map do |key|
         get(key) if stringy?(key)
       end

--- a/spec/commands/mget_spec.rb
+++ b/spec/commands/mget_spec.rb
@@ -49,5 +49,11 @@ describe '#mget(key [, key, ...])' do
         @redises.mget
       end.should raise_error(Redis::CommandError)
     end
+
+    it 'raises an error if you pass it empty array' do
+      lambda do
+        @redises.mget([])
+      end.should raise_error(Redis::CommandError)
+    end
   end
 end


### PR DESCRIPTION
- With redis
```
Redis.new.mget([])
# => raise Redis::CommandError: ERR wrong number of arguments for 'mget' command
```

- With mock_redis
```
MockRedis.new.mget([])
# => []
```