### PR TITLE
Ruby 2.7 error in set rspec test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -201,18 +201,17 @@ class MockRedis
       msetnx(*hash.to_a.flatten)
     end
 
-    def set(key, value, options = {})
+    def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
       key = key.to_s
       return_true = false
-      options = options.dup
-      if options.delete(:nx)
+      if nx
         if exists?(key)
           return false
         else
           return_true = true
         end
       end
-      if options.delete(:xx)
+      if xx
         if exists?(key)
           return_true = true
         else
@@ -221,23 +220,18 @@ class MockRedis
       end
       data[key] = value.to_s
 
-      duration = options.delete(:ex)
-      if duration
-        if duration == 0
+      if ex
+        if ex == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        expire(key, duration)
+        expire(key, ex)
       end
 
-      duration = options.delete(:px)
-      if duration
-        if duration == 0
+      if px
+        if px == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        pexpire(key, duration)
-      end
-      unless options.empty?
-        raise ArgumentError, "unknown keyword: #{options.keys[0]}"
+        pexpire(key, px)
       end
 
       return_true ? true : 'OK'

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -38,7 +38,7 @@ describe '#set(key, value)' do
       @redises.del(key)
       expect do
         @redises.set(key, 1, logger: :something)
-      end.to raise_error(ArgumentError, 'unknown keyword: logger')
+      end.to raise_error(ArgumentError, /unknown keyword/)
     end
 
     context '[mock only]' do


### PR DESCRIPTION
One of the RSpec tests for the `set` command (spec/commands/set_spec.rb:36) checks the error that is raised when there is an unexpected argument. This is an error raised by Ruby and the format has changed slightly between versions 2.6 and 2.7. For example, for the test code:

```ruby
def test arg1: ; end

test(arg1: 0, arg2: 1)
```

the output is:

```bash
# Ruby 2.6
Traceback (most recent call last):
	1: from test.rb:3:in `<main>'
test.rb:1:in `test': unknown keyword: arg2 (ArgumentError)

# Ruby 2.7
Traceback (most recent call last):
	1: from test.rb:3:in `<main>'
test.rb:1:in `test': unknown keyword: :arg2 (ArgumentError)
```

This difference is enough to make the test fail.

To fix this while ensuring that the error is consistent with the `redis` gem I have taken the full argument list from the `set` command in `lib/redis.rb` from the `redis/redis-rb` repository in place of `options = {}` and updated the code accordingly. I have also changed the test so that it only matches `unknown keyword` in the error response. Arguably, this test could be removed completely.

I have also added 2.7 as a version to test in Travis.