### PR TITLE
Ruby 2.7 error in set rspec test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -201,6 +201,8 @@ class MockRedis
       msetnx(*hash.to_a.flatten)
     end
 
+    # Parameer list required to ensure the ArgumentError is returned correctly
+    # rubocop:disable Metrics/ParameterLists
     def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
       key = key.to_s
       return_true = false
@@ -237,6 +239,7 @@ class MockRedis
 
       return_true ? true : 'OK'
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def setbit(key, offset, value)
       assert_stringy(key, 'ERR bit is not an integer or out of range')

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -201,18 +201,17 @@ class MockRedis
       msetnx(*hash.to_a.flatten)
     end
 
-    def set(key, value, options = {})
+    def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
       key = key.to_s
       return_true = false
-      options = options.dup
-      if options.delete(:nx)
+      if nx
         if exists?(key)
           return false
         else
           return_true = true
         end
       end
-      if options.delete(:xx)
+      if xx
         if exists?(key)
           return_true = true
         else
@@ -221,23 +220,18 @@ class MockRedis
       end
       data[key] = value.to_s
 
-      duration = options.delete(:ex)
-      if duration
-        if duration == 0
+      if ex
+        if ex == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        expire(key, duration)
+        expire(key, ex)
       end
 
-      duration = options.delete(:px)
-      if duration
-        if duration == 0
+      if px
+        if px == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
-        pexpire(key, duration)
-      end
-      unless options.empty?
-        raise ArgumentError, "unknown keyword: #{options.keys[0]}"
+        pexpire(key, px)
       end
 
       return_true ? true : 'OK'

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -220,6 +220,7 @@ class MockRedis
       end
       data[key] = value.to_s
 
+      remove_expiration(key) unless keepttl
       if ex
         if ex == 0
           raise Redis::CommandError, 'ERR invalid expire time in set'

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe '#set(key, value)' do
+  let(:key) { 'mock-redis-test' }
+
   it "responds with 'OK'" do
     @redises.set('mock-redis-test', 1).should == 'OK'
   end
@@ -19,22 +21,68 @@ describe '#set(key, value)' do
     end
 
     it 'accepts NX' do
-      key = 'mock-redis-test'
       @redises.del(key)
       @redises.set(key, 1, nx: true).should == true
       @redises.set(key, 1, nx: true).should == false
     end
 
     it 'accepts XX' do
-      key = 'mock-redis-test'
       @redises.del(key)
       @redises.set(key, 1, xx: true).should == false
       @redises.set(key, 1).should == 'OK'
       @redises.set(key, 1, xx: true).should == true
     end
 
+    it 'sets the ttl to -1' do
+      @redises.set(key, 1)
+      expect(@redises.ttl(key)).to eq(-1)
+    end
+
+    context 'with an expiry time' do
+      before :each do
+        Timecop.freeze
+        @redises.set(key, 1, ex: 90)
+      end
+
+      after :each do
+        @redises.del(key)
+        Timecop.return
+      end
+
+      it 'has the TTL set' do
+        expect(@redises.ttl(key)).to eq 90
+      end
+
+      it 'resets the TTL without keepttl' do
+        expect do
+          @redises.set(key, 2)
+        end.to change { @redises.ttl(key) }.from(90).to(-1)
+      end
+
+      it 'does not change the TTL with keepttl: true' do
+        expect do
+          @redises.set(key, 2, keepttl: true)
+        end.not_to change { @redises.ttl(key) }.from(90)
+      end
+    end
+
+    it 'accepts KEEPTTL' do
+      expect(@redises.set(key, 1, keepttl: true)).to eq 'OK'
+    end
+
+    it 'does not set TTL without ex' do
+      @redises.set(key, 1)
+      expect(@redises.ttl(key)).to eq(-1)
+    end
+
+    it 'sets the TTL' do
+      Timecop.freeze do
+        @redises.set(key, 1, ex: 90)
+        expect(@redises.ttl(key)).to eq 90
+      end
+    end
+
     it 'raises on unknown options' do
-      key = 'mock-redis-test'
       @redises.del(key)
       expect do
         @redises.set(key, 1, logger: :something)
@@ -52,7 +100,6 @@ describe '#set(key, value)' do
       end
 
       it 'accepts EX seconds' do
-        key = 'mock-redis-test'
         @mock.set(key, 1, ex: 1).should == 'OK'
         @mock.get(key).should_not be_nil
         Time.stub(:now).and_return(@now + 2)
@@ -60,7 +107,6 @@ describe '#set(key, value)' do
       end
 
       it 'accepts PX milliseconds' do
-        key = 'mock-redis-test'
         @mock.set(key, 1, px: 500).should == 'OK'
         @mock.get(key).should_not be_nil
         Time.stub(:now).and_return(@now + 300 / 1000.to_f)

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -38,7 +38,7 @@ describe '#set(key, value)' do
       @redises.del(key)
       expect do
         @redises.set(key, 1, logger: :something)
-      end.to raise_error(ArgumentError, 'unknown keyword: logger')
+      end.to raise_error(ArgumentError, /unknown keyword/)
     end
 
     context '[mock only]' do


### PR DESCRIPTION
(Reopening in spite of Rubocop as I don't think this can be fixed another way)

One of the RSpec tests for the set command (spec/commands/set_spec.rb:36) checks the error that is raised when there is an unexpected argument. This is an error raised by Ruby and the format has changed slightly between versions 2.6 and 2.7. For example, for the test code:

```ruby
def test arg1: ; end

test(arg1: 0, arg2: 1)
```

the output is:

```
# Ruby 2.6
Traceback (most recent call last):
	1: from test.rb:3:in `<main>'
test.rb:1:in `test': unknown keyword: arg2 (ArgumentError)

# Ruby 2.7
Traceback (most recent call last):
	1: from test.rb:3:in `<main>'
test.rb:1:in `test': unknown keyword: :arg2 (ArgumentError)
```

This difference is enough to make the test fail.

To fix this while ensuring that the error is consistent with the redis gem I have taken the full argument list from the set command in lib/redis.rb from the redis/redis-rb repository in place of `options = {}` and updated the code accordingly. I have also changed the test so that it only matches unknown keyword in the error response. Arguably, this test could be removed completely.

I have also added 2.7 as a version to test in Travis.

## Note 1

The test that is now failing (spec/commands/xadd_spec.rb:52) includes the comment:

```ruby
# TOOD: Redis version 6.0.4, w redis 4.2.1 generates the following error message:
# 'ERR The ID specified in XADD must be greater than 0-0'
```

This appears to be the reason for the failure.

## Note 2

There are Rubocop offenses that cannot be fixed:

```
Offenses:

lib/mock_redis/string_methods.rb:204:12: C: Metrics/ParameterLists: Avoid parameter lists longer than 5 parameters. [7/5]
    def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/mock_redis/string_methods.rb:204:61: W: Lint/UnusedMethodArgument: Unused method argument - keepttl.
    def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
                                                            ^^^^^^^

189 files inspected, 2 offenses detected
```

However, I do not think it is possible to simultaneously:

* Satisfy all the Rubocop rules
* Ensure that the correct argument errors are reported for all Ruby versions

What is the "correct" solution here?