### PR TITLE
Fix keyword arguments and stream specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,6 @@ gem 'overcommit', '0.53.0'
 # Pin tool versions (which are executed by Overcommit) for Travis builds
 gem 'rubocop', '0.82.0'
 
+gem 'ruby2_keywords'
+
 gem 'coveralls', require: false

--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -84,7 +84,7 @@ class MockRedis
     super || @db.respond_to?(method, include_private)
   end
 
-  def method_missing(method, *args, &block)
+  ruby2_keywords def method_missing(method, *args, &block)
     @db.send(method, *args, &block)
   end
 

--- a/lib/mock_redis/expire_wrapper.rb
+++ b/lib/mock_redis/expire_wrapper.rb
@@ -12,7 +12,7 @@ class MockRedis
       @db = db
     end
 
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       @db.expire_keys
       @db.send(method, *args, &block)
     end

--- a/lib/mock_redis/geospatial_methods.rb
+++ b/lib/mock_redis/geospatial_methods.rb
@@ -12,7 +12,7 @@ class MockRedis
     D_R = Math::PI / 180.0
     EARTH_RADIUS_IN_METERS = 6_372_797.560856
 
-    def geoadd(key, *args)
+    ruby2_keywords def geoadd(key, *args)
       points = parse_points(args)
 
       scored_points = points.map do |point|

--- a/lib/mock_redis/multi_db_wrapper.rb
+++ b/lib/mock_redis/multi_db_wrapper.rb
@@ -17,7 +17,7 @@ class MockRedis
       super || current_db.respond_to?(method, include_private)
     end
 
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       current_db.send(method, *args, &block)
     end
 

--- a/lib/mock_redis/pipelined_wrapper.rb
+++ b/lib/mock_redis/pipelined_wrapper.rb
@@ -18,7 +18,7 @@ class MockRedis
       @pipelined_futures = @pipelined_futures.clone
     end
 
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       if in_pipeline?
         future = MockRedis::Future.new([method, *args], block)
         @pipelined_futures << future

--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -15,7 +15,7 @@ class MockRedis
       @multi_block_given = false
     end
 
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       if in_multi?
         future = MockRedis::Future.new([method, *args], block)
         @transaction_futures << future

--- a/spec/commands/del_spec.rb
+++ b/spec/commands/del_spec.rb
@@ -6,7 +6,9 @@ describe '#del(key [, key, ...])' do
   end
 
   before :each do
-    @redises._gsub(/\d{3}-\d/, '...-.')
+    # TODO: Redis appears to be returning a timestamp a few seconds in the future
+    # so we're ignoring the last 5 digits (time in milliseconds)
+    @redises._gsub(/\d{5}-\d/, '...-.')
   end
 
   it 'returns the number of keys deleted' do

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -7,11 +7,14 @@ describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, app
   end
 
   before :each do
-    @redises._gsub(/\d{3}-\d/, '...-.')
+    # TODO: Redis appears to be returning a timestamp a few seconds in the future
+    # so we're ignoring the last 5 digits (time in milliseconds)
+    @redises._gsub(/\d{5}-\d/, '....-.')
   end
 
   it 'returns an id based on the timestamp' do
     t = Time.now.to_i
+    id = @redises.xadd(@key, key: 'value')
     expect(@redises.xadd(@key, key: 'value')).to match(/#{t}\d{3}-0/)
   end
 

--- a/spec/commands/xlen_spec.rb
+++ b/spec/commands/xlen_spec.rb
@@ -7,7 +7,9 @@ describe '#xlen(key)' do
   end
 
   before :each do
-    @redises._gsub(/\d{3}-\d/, '...-.')
+    # TODO: Redis appears to be returning a timestamp a few seconds in the future
+    # so we're ignoring the last 5 digits (time in milliseconds)
+    @redises._gsub(/\d{5}-\d/, '...-.')
   end
 
   it 'returns the number of items in the stream' do

--- a/spec/support/redis_multiplexer.rb
+++ b/spec/support/redis_multiplexer.rb
@@ -23,7 +23,7 @@ class RedisMultiplexer < BlankSlate
     @gsub_from = @gsub_to = ''
   end
 
-  def method_missing(method, *args, &blk)
+  ruby2_keywords def method_missing(method, *args, &blk)
     # If we're in a Redis command that accepts a block, and we execute more
     # redis commands, ONLY execute them on the Redis implementation that the
     # block came from.


### PR DESCRIPTION
Ruby 3.0 handles keyword arguments differently: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This attempts to fix that issue. Note there are still two warnings that I'm not sure how to fix in redis_multiplexer.rb method_missing.