### PR TITLE
Allow for passing a string value to the setbit method 

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -247,6 +247,7 @@ class MockRedis
 
       str = data[key] || ''
 
+      offset = offset.to_i
       offset_of_byte = offset / 8
       offset_within_byte = offset % 8
 


### PR DESCRIPTION
for the offset argument. The redis client seems to allow for it. 