### PR TITLE
Add #connection method

### DIFF
--- a/lib/mock_redis/connection_method.rb
+++ b/lib/mock_redis/connection_method.rb
@@ -1,0 +1,13 @@
+class MockRedis
+  module ConnectionMethod
+    def connection
+      {
+        :host => @base.host,
+        :port => @base.port,
+        :db => @base.db,
+        :id => @base.id,
+        :location => "#{@base.host}:#{@base.port}"
+      }
+    end
+  end
+end

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -11,6 +11,7 @@ require 'mock_redis/info_method'
 require 'mock_redis/utility_methods'
 require 'mock_redis/geospatial_methods'
 require 'mock_redis/stream_methods'
+require 'mock_redis/connection_method'
 
 class MockRedis
   class Database
@@ -24,6 +25,7 @@ class MockRedis
     include UtilityMethods
     include GeospatialMethods
     include StreamMethods
+    include ConnectionMethod
 
     attr_reader :data, :expire_times
 

--- a/spec/commands/connection_spec.rb
+++ b/spec/commands/connection_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe '#connection' do
+  let(:redis) { @redises.mock }
+
+  it 'returns the correct values' do
+    redis.connection.should == {
+      :host => '127.0.0.1',
+      :port => 6379,
+      :db => 0,
+      :id => 'redis://127.0.0.1:6379/0',
+      :location => '127.0.0.1:6379'
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 require 'rspec/its'
 require 'redis'
 $LOAD_PATH.unshift(File.expand_path(File.join(__FILE__, '..', '..', 'lib')))
+require 'ruby2_keywords'
 require 'mock_redis'
 require 'timecop'
 


### PR DESCRIPTION
This adds the `#connection` method that the `redis` client gem has to `mock_redis`.

I also added a require for `ruby2_keywords` to the spec_helper.rb, without which the specs fail on ruby 2.6 (for me).