### PR TITLE
Allow for passing a string value to the getbit method

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -93,6 +93,7 @@ class MockRedis
     def getbit(key, offset)
       assert_stringy(key)
 
+      offset = offset.to_i
       offset_of_byte = offset / 8
       offset_within_byte = offset % 8
 


### PR DESCRIPTION
#200 setbit allow string value, but getbit not allow string value.

```
> require 'mock_redis'
> mr = MockRedis.new
> mr.set "key", "A"
> mr.setbit "key", "6", 1
NoMethodError: undefined method `/' for "6":String
from mock_redis-0.27.0/lib/mock_redis/string_methods.rb:96:in `getbit'
```

Fix above error.