### PR TITLE
Add is_a? method to better mock redis

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -48,7 +48,12 @@ class MockRedis
     "redis://#{host}:#{port}/#{db}"
   end
   alias location id
-
+  
+  def is_a?(klass)
+    return true if klass.to_s == Redis
+    super
+  end
+  
   def call(command, &_block)
     send(*command)
   end


### PR DESCRIPTION
I had some issues that requires monkey pathcing because tested classes was checking if proper redis client was passed. That should help