### PR TITLE
hset was not accepting hashes as a parameter

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -131,6 +131,10 @@ class MockRedis
     def hset(key, *args)
       added = 0
       with_hash_at(key) do |hash|
+        if args.length == 1 && args[0].is_a?(Hash)
+          args = args[0].to_a.flatten
+        end
+
         args.each_slice(2) do |field, value|
           added += 1 unless hash.key?(field.to_s)
           hash[field.to_s] = value.to_s

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -34,5 +34,9 @@ describe '#hset(key, field)' do
     @redises.hget(@key, '1').should == 'one'
   end
 
+  it 'stores fields sent in a hash' do
+    @redises.hset(@key, {'k1' => 'v1', 'k2' => 'v2'}).should == 2
+  end
+
   it_should_behave_like 'a hash-only command'
 end


### PR DESCRIPTION
Since 4.0.0, hset has allowed a Hash to be sent instead of key value pairs.  