### PR TITLE
Allow mget to accept a block

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -154,14 +154,16 @@ class MockRedis
       new_value
     end
 
-    def mget(*keys)
+    def mget(*keys, &blk)
       keys.flatten!
 
       assert_has_args(keys, 'mget')
 
-      keys.map do |key|
+      data = keys.map do |key|
         get(key) if stringy?(key)
       end
+
+      blk ? blk.call(data) : data
     end
 
     def mapped_mget(*keys)

--- a/spec/commands/mget_spec.rb
+++ b/spec/commands/mget_spec.rb
@@ -56,4 +56,10 @@ describe '#mget(key [, key, ...])' do
       end.should raise_error(Redis::CommandError)
     end
   end
+
+  context 'emulate block' do
+    it 'returns an array of values' do
+      @redises.mget(@key1, @key2) { |values| values.map(&:to_i) }.should == [1, 2]
+    end
+  end
 end


### PR DESCRIPTION
From [redis-rb](https://github.com/redis/redis-rb/blob/6542934f01b9c390ee450bd372209a04bc3a239b/lib/redis.rb#L970), `mget` accepts a block.