### PR TITLE
Add support for Redis' logger option

### DIFF
--- a/spec/mock_redis_spec.rb
+++ b/spec/mock_redis_spec.rb
@@ -81,4 +81,13 @@ describe MockRedis do
       end
     end
   end
+
+  describe 'supplying a logger' do
+    it 'logs redis commands' do
+      logger = double('Logger', debug?: true, debug: nil)
+      mock_redis = MockRedis.new(logger: logger)
+      expect(logger).to receive(:debug).with(/command=HMGET args="hash" "key1" "key2"/)
+      mock_redis.hmget("hash", "key1", "key2")
+    end
+  end
 end


### PR DESCRIPTION
This allows passing a `:logger` option to `MockRedis.new`. The logging method is mostly ripped from redis' implementation here: https://github.com/redis/redis-rb/blob/6542934f01b9c390ee450bd372209a04bc3a239b/lib/redis/client.rb#L329-L351. As a result it also logs call_time - I'm not sure that's especially useful for MockRedis, but have left it in for the sake of mimicking the Redis implementation.

See also #198 