### PR TITLE
Removing conditional type coercion for zset.add

### DIFF
--- a/lib/mock_redis/zset.rb
+++ b/lib/mock_redis/zset.rb
@@ -23,12 +23,7 @@ class MockRedis
 
     def add(score, member)
       members.add(member)
-      scores[member] =
-        if score.to_f.to_i == score.to_f
-          score.to_f.to_i
-        else
-          score.to_f
-        end
+      scores[member] = score.to_f
       self
     end
 

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -23,6 +23,12 @@ describe '#zadd(key, score, member)' do
     @redises.zrange(@key, 0, -1).should == [member.to_s]
   end
 
+  it 'allows scores to be set to Float::INFINITY' do
+    member = '1'
+    @redises.zadd(@key, Float::INFINITY, member)
+    @redises.zrange(@key, 0, -1).should == [member]
+  end
+
   it 'updates the score' do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'foo')


### PR DESCRIPTION
Redis [represents zset scores as floats](https://redis.io/commands/ZADD) internally, but `mock_redis` attempts to [coerce zset scores to integers](https://github.com/sds/mock_redis/blob/master/lib/mock_redis/zset.rb#L27). This coercion prevents certain float values from being used as scores (eg. `Float::INFINITY`).

This PR removes the conditional type coercion from the zset `add` method, and instead converts all scores to floats.