### PR TITLE
Update supported Redis to 6 in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for use in tests.
 
 * Ruby 2.4+
 
-The current implementation is tested against **Redis 5**. Older versions may work, but can also return different results or not support some commands.
+The current implementation is tested against **Redis 6**. Older versions may work, but can also return different results or not support some commands.
 
 ## Getting Started
 


### PR DESCRIPTION
I run the test against Redis 5.0.9 and there are 4 failed tests. When changing to Redis 6.2.1, all the tests pass. I think the documentation can be updated to avoid misunderstanding.