### PR TITLE
redis.expire('a', nil) should raise CommandError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -86,27 +86,27 @@ class MockRedis
     end
 
     def expire(key, seconds)
+      assert_valid_integer(seconds)
+
       pexpire(key, seconds.to_i * 1000)
     end
 
     def pexpire(key, ms)
+      assert_valid_integer(ms)
+
       now, miliseconds = @base.now
       now_ms = (now * 1000) + miliseconds
       pexpireat(key, now_ms + ms.to_i)
     end
 
     def expireat(key, timestamp)
-      unless looks_like_integer?(timestamp.to_s)
-        raise Redis::CommandError, 'ERR value is not an integer or out of range'
-      end
+      assert_valid_integer(timestamp)
 
       pexpireat(key, timestamp.to_i * 1000)
     end
 
     def pexpireat(key, timestamp_ms)
-      unless looks_like_integer?(timestamp_ms.to_s)
-        raise Redis::CommandError, 'ERR value is not an integer or out of range'
-      end
+      assert_valid_integer(timestamp_ms)
 
       if exists?(key)
         timestamp = Rational(timestamp_ms.to_i, 1000)
@@ -279,6 +279,13 @@ class MockRedis
     def eval(*args); end
 
     private
+
+    def assert_valid_integer(integer)
+      if !looks_like_integer?(integer.to_s)
+        raise Redis::CommandError, 'ERR value is not an integer or out of range'
+      end
+      integer
+    end
 
     def assert_valid_timeout(timeout)
       if !looks_like_integer?(timeout.to_s)

--- a/spec/commands/expire_spec.rb
+++ b/spec/commands/expire_spec.rb
@@ -21,7 +21,7 @@ describe '#expire(key, seconds)' do
 
   it 'raises an error if seconds is bogus' do
     lambda do
-      @redises.expireat(@key, 'a couple minutes or so')
+      @redises.expire(@key, 'a couple minutes or so')
     end.should raise_error(Redis::CommandError)
   end
 

--- a/spec/commands/pexpire_spec.rb
+++ b/spec/commands/pexpire_spec.rb
@@ -21,7 +21,7 @@ describe '#pexpire(key, ms)' do
 
   it 'raises an error if ms is bogus' do
     lambda do
-      @redises.pexpireat(@key, 'a couple minutes or so')
+      @redises.pexpire(@key, 'a couple minutes or so')
     end.should raise_error(Redis::CommandError)
   end
 

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -14,7 +14,6 @@ describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, app
 
   it 'returns an id based on the timestamp' do
     t = Time.now.to_i
-    id = @redises.xadd(@key, { key: 'value' })
     expect(@redises.xadd(@key, { key: 'value' })).to match(/#{t}\d{3}-0/)
   end
 


### PR DESCRIPTION
We already had specs for this (eg "#expire raises an error if seconds is bogus"), but looks like they were accidentally testing `expireat` rather than `expire`.  I've fixed that, and added ruby 3 to the test matrix.