### PR TITLE
Update README with Ruby/Redis version support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: Lint
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   overcommit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   rspec:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ for use in tests.
 
 ## Requirements
 
-* Ruby 2.4+
+Ruby 2.6+
 
-The current implementation is tested against **Redis 6**. Older versions may work, but can also return different results or not support some commands.
+The current implementation is tested against Redis 6.2. Older versions may work, but can also return different results or not support some commands.
 
 ## Getting Started
 


### PR DESCRIPTION
Quick update about version support.

While here, also fix the branch name since the default is now `main`.