### PR TITLE
Update `redis` dev dependency to require `4.3.0`+

### DIFF
--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'ruby2_keywords'
 
-  s.add_development_dependency 'redis', '~> 4.2.0'
+  s.add_development_dependency 'redis', '~> 4.3.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'
   s.add_development_dependency 'timecop', '~> 0.9.1'


### PR DESCRIPTION
As discussed in #218, we should update the dependency so we are consistent in which version of `.exists` we support.
