### PR TITLE
Fix Coveralls to work on GH Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,21 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+      - name: Code coverage reporting
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: ruby${{ matrix.ruby-version }}-${{ matrix.redis-version }}
+          parallel: true
+
+  finish:
+    needs: rspec
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Finalize code coverage report
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ gem 'overcommit', '0.53.0'
 # Pin tool versions (which are executed by Overcommit) for Travis builds
 gem 'rubocop', '0.82.0'
 
-gem 'coveralls', require: false
+gem 'simplecov', '~> 0.21.0'
+gem 'simplecov-lcov', '~> 0.8.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,17 @@
-if ENV['TRAVIS']
-  # When running in Travis, report coverage stats to Coveralls.
-  require 'coveralls'
-  Coveralls.wear!
-else
-  # Otherwise render coverage information in coverage/index.html and display
-  # coverage percentage in the console.
-  require 'simplecov'
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec/'
+
+  if ENV['CI']
+    require 'simplecov-lcov'
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      c.single_report_path = 'coverage/lcov.info'
+    end
+
+    formatter SimpleCov::Formatter::LcovFormatter
+  end
 end
 
 require 'rspec/its'


### PR DESCRIPTION
Our migrations to GH Actions broke this since `TRAVIS` is not defined in this environment, and furthermore we needed to include some GH Actions to explicitly upload coverage reports.
