### PR TITLE
Cut version 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MockRedis Changelog
 
+### 0.31.0
+
+* Allow `ping` to take argument
+* Raise `CommandError` on `hmget` with empty list of fields
+
 ### 0.30.0
 
 * Drop support for Ruby 2.4 and Ruby 2.5 since they are EOL

--- a/lib/mock_redis/version.rb
+++ b/lib/mock_redis/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 class MockRedis
-  VERSION = '0.30.0'
+  VERSION = '0.31.0'
 end


### PR DESCRIPTION
* Allow `ping` to take argument
* Raise `CommandError` on `hmget` with empty list of fields
