### PR TITLE
add support for PSETEX

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -328,6 +328,16 @@ class MockRedis
       end
     end
 
+    def psetex(key, milliseconds, value)
+      if milliseconds <= 0
+        raise Redis::CommandError, 'ERR invalid expire time in psetex'
+      else
+        set(key, value)
+        pexpire(key, milliseconds)
+        'OK'
+      end
+    end
+
     def setnx(key, value)
       if exists?(key)
         false

--- a/spec/commands/psetex_spec.rb
+++ b/spec/commands/psetex_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe '#psetex(key, miliseconds, value)' do
+  before { @key = 'mock-redis-test:setex' }
+
+  it "responds with 'OK'" do
+    @redises.psetex(@key, 10, 'value').should == 'OK'
+  end
+
+  it 'sets the value' do
+    @redises.psetex(@key, 10_000, 'value')
+    @redises.get(@key).should == 'value'
+  end
+
+  it 'sets the expiration time' do
+    @redises.psetex(@key, 10_000, 'value')
+
+    # no guarantee these are the same
+    @redises.real.ttl(@key).should > 0
+    @redises.mock.ttl(@key).should > 0
+  end
+
+  it 'converts time correctly' do
+    @redises.psetex(@key, 10_000_000, 'value')
+
+    @redises.mock.ttl(@key).should > 9_000
+  end
+
+  context 'when expiration time is zero' do
+    it 'raises Redis::CommandError' do
+      expect do
+        @redises.psetex(@key, 0, 'value')
+      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in psetex')
+    end
+  end
+
+  context 'when expiration time is negative' do
+    it 'raises Redis::CommandError' do
+      expect do
+        @redises.psetex(@key, -2, 'value')
+      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in psetex')
+    end
+  end
+end


### PR DESCRIPTION
Currently mock_redis does not work if used as [moneta](https://github.com/moneta-rb/moneta) backend because it [uses PSETEX](https://github.com/moneta-rb/moneta/blob/9c81f72a2a3922ab193523c8282e75b2cc44c560/lib/moneta/adapters/redis.rb#L52) to set the key expiration times in Redis. This PR adds basic support for [PSETEX](https://redis.io/commands/psetex/) command.