### PR TITLE
Update tests documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ We recommend running Redis within a Docker container to make development as simp
 
 1. Start Redis.
    ```bash
-   docker run --rm -p 6379:6379 redis
+   docker run --rm -p 6379:6379 redis:6.2-alpine
    ```
 2. Install dependencies.
    ```bash


### PR DESCRIPTION
Recommend to use the same docker image as the one [used in the CI](https://github.com/sds/mock_redis/blob/main/.github/workflows/tests.yml#L20-L24), as docker `redis` alias [represents version 7.x as of today](https://hub.docker.com/_/redis).