### PR TITLE
Add MockRedis#with

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -86,6 +86,10 @@ class MockRedis
     self
   end
 
+  def with
+    yield self
+  end
+
   def respond_to?(method, include_private = false)
     super || @db.respond_to?(method, include_private)
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -26,4 +26,11 @@ describe 'client' do
       expect(MockRedis.new).to respond_to(:close)
     end
   end
+
+  context '#with' do
+    it 'supports with' do
+      redis = MockRedis.new
+      redis.with { |c| c.set('key', 'value') }.should == 'OK'
+    end
+  end
 end


### PR DESCRIPTION
Add [missing API from redis-rb](https://github.com/redis/redis-rb/blob/3037564001edb36a839b41b577c83241c85121a8/lib/redis.rb#L94-L96) (added in commit https://github.com/redis/redis-rb/commit/674541c5cc162b46066556811967a28a184f4665).

It is needed if you want to use `mock_redis` with `ActiveSupport::Cache::RedisCacheStore` from Rails 7.0 ([see source code](https://github.com/rails/rails/blob/04972d9b9ef60796dc8f0917817b5392d61fcf09/activesupport/lib/active_support/cache/redis_cache_store.rb#L239)).

Notes:
- Rails maintains [a similar patch](https://github.com/rails/rails/blob/v7.0.3.1/activesupport/lib/active_support/cache/redis_cache_store.rb#L22-L26) for `ConnectionPoolLike`.
- They switched from `with` to `then` on [Rails main branch](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/cache/redis_cache_store.rb)