### PR TITLE
feat: Implement getdel command

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -107,6 +107,12 @@ class MockRedis
       end
     end
 
+    def getdel(key)
+      value = get(key)
+      del(key)
+      value
+    end
+
     def getrange(key, start, stop)
       assert_stringy(key)
       (data[key] || '')[start..stop]

--- a/spec/commands/getdel.rb
+++ b/spec/commands/getdel.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe '#getdel(key)' do
+  before do
+    @key = 'mock-redis-test:73288'
+  end
+
+  it 'returns nil for a nonexistent value' do
+    @redises.getdel('mock-redis-test:does-not-exist').should be_nil
+  end
+
+  it 'returns a stored string value' do
+    @redises.set(@key, 'forsooth')
+    @redises.getdel(@key).should == 'forsooth'
+  end
+
+  it 'deletes the key after returning it' do
+    @redises.set(@key, 'forsooth')
+    @redises.getdel(@key)
+    @redises.get(@key).should be_nil
+  end
+
+  it_should_behave_like 'a string-only command'
+end


### PR DESCRIPTION
This adds support to [GETDEL](https://redis.io/commands/getdel/) introduced in Redis 6.2.0 (implemented on commit https://github.com/redis/redis-rb/commit/94d606c04c0322600cf1c4dfe4ebba12155e7ea5)

I initially implemented it as

```ruby
    def getdel(key)
      get(key).tap { del(key) }
    end
```

but I couldn't find `tap` usages on the codebase, so I preferred to introduce a variable, and return it after the `del` call. Please do let me know in case there's a standard to follow.

Thanks!