### PR TITLE
Add LMOVE and BLMOVE commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ since it's an in-memory object confined to a single process. MockRedis
 makes every attempt to be Redis-compatible, but there are some
 necessary exceptions.
 
-* Blocking list commands (`#blpop`, `#brpop`, and `#brpoplpush`) work
-  as expected if there is data for them to retrieve. If you use one of
+* Blocking list commands (`#blmove`, `#blpop`, `#brpop`, and `#brpoplpush`)
+  work as expected if there is data for them to retrieve. If you use one of
   these commands with a nonzero timeout and there is no data for it to
   retrieve, then the command returns immediately. However, if you ask
   one of these commands for data with a 0 timeout (means "wait

--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -6,6 +6,20 @@ class MockRedis
     include Assertions
     include UtilityMethods
 
+    def blmove(source, destination, wherefrom, whereto, options = {})
+      options = { :timeout => options } if options.is_a?(Integer)
+      timeout = options.is_a?(Hash) && options[:timeout] || 0
+      assert_valid_timeout(timeout)
+
+      if llen(source) > 0
+        lmove(source, destination, wherefrom, whereto)
+      elsif timeout > 0
+        nil
+      else
+        raise MockRedis::WouldBlock, "Can't block forever"
+      end
+    end
+
     def blpop(*args)
       lists, timeout = extract_timeout(args)
       nonempty_list = first_nonempty_list(lists)

--- a/lib/mock_redis/list_methods.rb
+++ b/lib/mock_redis/list_methods.rb
@@ -78,6 +78,22 @@ class MockRedis
       with_list_at(key, &:length)
     end
 
+    def lmove(source, destination, wherefrom, whereto)
+      assert_listy(source)
+      assert_listy(destination)
+
+      wherefrom = wherefrom.to_s.downcase
+      whereto = whereto.to_s.downcase
+
+      unless %w[left right].include?(wherefrom) && %w[left right].include?(whereto)
+        raise Redis::CommandError, 'ERR syntax error'
+      end
+
+      value = wherefrom == 'left' ? lpop(source) : rpop(source)
+      (whereto == 'left' ? lpush(destination, value) : rpush(destination, value)) unless value.nil?
+      value
+    end
+
     def lpop(key)
       with_list_at(key, &:shift)
     end

--- a/spec/commands/blmove_spec.rb
+++ b/spec/commands/blmove_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
+  before do
+    @list1 = 'mock-redis-test:blmove-list1'
+    @list2 = 'mock-redis-test:blmove-list2'
+
+    @redises.lpush(@list1, 'b')
+    @redises.lpush(@list1, 'a')
+
+    @redises.lpush(@list2, 'y')
+    @redises.lpush(@list2, 'x')
+  end
+
+  it 'returns the value moved' do
+    @redises.blmove(@list1, @list2, 'left', 'right').should == 'a'
+  end
+
+  it 'takes the first element of source and appends it to destination' do
+    @redises.blmove(@list1, @list2, 'left', 'right')
+
+    @redises.lrange(@list1, 0, -1).should == %w[b]
+    @redises.lrange(@list2, 0, -1).should == %w[x y a]
+  end
+
+  it 'raises an error on negative timeout' do
+    lambda do
+      @redises.blmove(@list1, @list2, 'left', 'right', :timeout => -1)
+    end.should raise_error(Redis::CommandError)
+  end
+
+  let(:default_error) { RedisMultiplexer::MismatchedResponse }
+  it_should_behave_like 'a list-only command'
+
+  context '[mock only]' do
+    it 'ignores positive timeouts and returns nil' do
+      @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 1).
+        should be_nil
+    end
+
+    it 'ignores positive legacy timeouts and returns nil' do
+      @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', 1).
+        should be_nil
+    end
+
+    it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
+      lambda do
+        @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 0)
+      end.should raise_error(MockRedis::WouldBlock)
+    end
+  end
+end

--- a/spec/commands/lmove_spec.rb
+++ b/spec/commands/lmove_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe '#lmove(source, destination, wherefrom, whereto)' do
+  before do
+    @list1 = 'mock-redis-test:lmove-list1'
+    @list2 = 'mock-redis-test:lmove-list2'
+
+    @redises.lpush(@list1, 'b')
+    @redises.lpush(@list1, 'a')
+
+    @redises.lpush(@list2, 'y')
+    @redises.lpush(@list2, 'x')
+  end
+
+  it 'returns the value moved' do
+    @redises.lmove(@list1, @list2, 'left', 'right').should == 'a'
+  end
+
+  it "returns nil and doesn't append if source empty" do
+    @redises.lmove('empty', @list1, 'left', 'right').should be_nil
+    @redises.lrange(@list1, 0, -1).should == %w[a b]
+  end
+
+  it 'takes the first element of source and prepends it to destination' do
+    @redises.lmove(@list1, @list2, 'left', 'left')
+
+    @redises.lrange(@list1, 0, -1).should == %w[b]
+    @redises.lrange(@list2, 0, -1).should == %w[a x y]
+  end
+
+  it 'takes the first element of source and appends it to destination' do
+    @redises.lmove(@list1, @list2, 'left', 'right')
+
+    @redises.lrange(@list1, 0, -1).should == %w[b]
+    @redises.lrange(@list2, 0, -1).should == %w[x y a]
+  end
+
+  it 'takes the last element of source and prepends it to destination' do
+    @redises.lmove(@list1, @list2, 'right', 'left')
+
+    @redises.lrange(@list1, 0, -1).should == %w[a]
+    @redises.lrange(@list2, 0, -1).should == %w[b x y]
+  end
+
+  it 'takes the last element of source and appends it to destination' do
+    @redises.lmove(@list1, @list2, 'right', 'right')
+
+    @redises.lrange(@list1, 0, -1).should == %w[a]
+    @redises.lrange(@list2, 0, -1).should == %w[x y b]
+  end
+
+  it 'rotates a list when source and destination are the same' do
+    @redises.lmove(@list1, @list1, 'left', 'right')
+    @redises.lrange(@list1, 0, -1).should == %w[b a]
+  end
+
+  it 'removes empty lists' do
+    @redises.llen(@list1).times { @redises.lmove(@list1, @list2, 'left', 'right') }
+    @redises.get(@list1).should be_nil
+  end
+
+  it 'raises an error for non-list source value' do
+    @redises.set(@list1, 'string value')
+
+    lambda do
+      @redises.lmove(@list1, @list2, 'left', 'right')
+    end.should raise_error(Redis::CommandError)
+  end
+
+  let(:default_error) { RedisMultiplexer::MismatchedResponse }
+  it_should_behave_like 'a list-only command'
+end


### PR DESCRIPTION
Added in Redis 6.2.0, the LMOV and BLMOVE commands succeed RPOPLPUSH and BRPOPLPUSH commands.