### PR TITLE
Fix zrem with array of integers

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -147,7 +147,7 @@ class MockRedis
         else
           retval = args.map { |member| !!zscore(key, member.to_s) }.count(true)
           with_zset_at(key) do |z|
-            args.each { |member| z.delete?(member) }
+            args.each { |member| z.delete?(member.to_s) }
           end
         end
       end

--- a/spec/commands/zrem_spec.rb
+++ b/spec/commands/zrem_spec.rb
@@ -28,6 +28,13 @@ describe '#zrem(key, member)' do
     @redises.zrange(@key, 0, -1).should == %w[one two]
   end
 
+  it 'removes integer members inside an array from the set' do
+    member = 11
+    @redises.zadd(@key, 3, member)
+    @redises.zrem(@key, [member]).should == 1
+    @redises.zrange(@key, 0, -1).should == %w[one two]
+  end
+
   it 'supports a variable number of arguments' do
     @redises.zrem(@key, %w[one two])
     @redises.zrange(@key, 0, -1).should be_empty


### PR DESCRIPTION
When using zrem with an integer like this `zrem(@key, [11])` it did not convert the member to a string and therefore did not remove the member from the set.