### PR TITLE
RSpec: use expect assertion syntax

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe 'client' do
+RSpec.describe 'client' do
   context '#reconnect' do
     it 'reconnects' do
       redis = MockRedis.new
-      redis.reconnect.should == redis
+      expect(redis.reconnect).to eq(redis)
     end
   end
 
   context '#connect' do
     it 'connects' do
       redis = MockRedis.new
-      redis.connect.should == redis
+      expect(redis.connect).to eq(redis)
     end
   end
 
@@ -30,7 +30,7 @@ describe 'client' do
   context '#with' do
     it 'supports with' do
       redis = MockRedis.new
-      redis.with { |c| c.set('key', 'value') }.should == 'OK'
+      expect(redis.with { |c| c.set('key', 'value') }).to eq('OK')
     end
   end
 end

--- a/spec/cloning_spec.rb
+++ b/spec/cloning_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'MockRedis#clone' do
+RSpec.describe 'MockRedis#clone' do
   before do
     @mock = MockRedis.new
   end
@@ -17,32 +17,32 @@ describe 'MockRedis#clone' do
     end
 
     it 'copies the stored data to the clone' do
-      @clone.get('foo').should == 'bar'
+      expect(@clone.get('foo')).to eq('bar')
     end
 
     it 'performs a deep copy (string values)' do
       @mock.del('foo')
-      @clone.get('foo').should == 'bar'
+      expect(@clone.get('foo')).to eq('bar')
     end
 
     it 'performs a deep copy (list values)' do
       @mock.lpop('foolist')
-      @clone.lrange('foolist', 0, 1).should == ['bar']
+      expect(@clone.lrange('foolist', 0, 1)).to eq(['bar'])
     end
 
     it 'performs a deep copy (hash values)' do
       @mock.hset('foohash', 'bar', 'quux')
-      @clone.hgetall('foohash').should == { 'bar' => 'baz' }
+      expect(@clone.hgetall('foohash')).to eq({ 'bar' => 'baz' })
     end
 
     it 'performs a deep copy (set values)' do
       @mock.srem('fooset', 'bar')
-      @clone.smembers('fooset').should == ['bar']
+      expect(@clone.smembers('fooset')).to eq(['bar'])
     end
 
     it 'performs a deep copy (zset values)' do
       @mock.zadd('foozset', 2, 'bar')
-      @clone.zscore('foozset', 'bar').should == 1.0
+      expect(@clone.zscore('foozset', 'bar')).to eq(1.0)
     end
   end
 
@@ -55,17 +55,17 @@ describe 'MockRedis#clone' do
     end
 
     it 'copies the expiration times' do
-      @clone.ttl('foo').should > 0
+      expect(@clone.ttl('foo')).to be > 0
     end
 
     it 'deep-copies the expiration times' do
       @mock.persist('foo')
-      @clone.ttl('foo').should > 0
+      expect(@clone.ttl('foo')).to be > 0
     end
 
     it 'deep-copies the expiration times' do
       @clone.persist('foo')
-      @mock.ttl('foo').should > 0
+      expect(@mock.ttl('foo')).to be > 0
     end
   end
 
@@ -80,16 +80,16 @@ describe 'MockRedis#clone' do
     end
 
     it 'makes sure the clone is in a transaction' do
-      lambda do
+      expect do
         @clone.exec
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'deep-copies the queued commands' do
       @clone.incrby('foo', 8)
-      @clone.exec.should == [1, 3, 7, 15]
+      expect(@clone.exec).to eq([1, 3, 7, 15])
 
-      @mock.exec.should == [1, 3, 7]
+      expect(@mock.exec).to eq([1, 3, 7])
     end
   end
 end

--- a/spec/commands/append_spec.rb
+++ b/spec/commands/append_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe '#append(key, value)' do
+RSpec.describe '#append(key, value)' do
   before { @key = 'mock-redis-test:append' }
 
   it 'returns the new length of the string' do
     @redises.set(@key, 'porkchop')
-    @redises.append(@key, 'sandwiches').should == 18
+    expect(@redises.append(@key, 'sandwiches')).to eq(18)
   end
 
   it 'appends value to the previously-stored value' do
     @redises.set(@key, 'porkchop')
     @redises.append(@key, 'sandwiches')
 
-    @redises.get(@key).should == 'porkchopsandwiches'
+    expect(@redises.get(@key)).to eq('porkchopsandwiches')
   end
 
   it 'treats a missing key as an empty string' do
     @redises.append(@key, 'foo')
-    @redises.get(@key).should == 'foo'
+    expect(@redises.get(@key)).to eq('foo')
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/auth_spec.rb
+++ b/spec/commands/auth_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#auth(password) [mock only]' do
+RSpec.describe '#auth(password) [mock only]' do
   it "just returns 'OK'" do
-    @redises.mock.auth('foo').should == 'OK'
+    expect(@redises.mock.auth('foo')).to eq('OK')
   end
 end

--- a/spec/commands/bgrewriteaof_spec.rb
+++ b/spec/commands/bgrewriteaof_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#bgrewriteaof [mock only]' do
+RSpec.describe '#bgrewriteaof [mock only]' do
   it 'just returns a canned string' do
-    @redises.mock.bgrewriteaof.should =~ /append/
+    expect(@redises.mock.bgrewriteaof).to match(/append/)
   end
 end

--- a/spec/commands/bgsave_spec.rb
+++ b/spec/commands/bgsave_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#bgsave [mock only]' do
+RSpec.describe '#bgsave [mock only]' do
   it 'just returns a canned string' do
-    @redises.mock.bgsave.should =~ /saving/
+    expect(@redises.mock.bgsave).to match(/saving/)
   end
 end

--- a/spec/commands/bitcount_spec.rb
+++ b/spec/commands/bitcount_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
-describe '#bitcount(key [, start, end ])' do
+RSpec.describe '#bitcount(key [, start, end ])' do
   before do
     @key = 'mock-redis-test:bitcount'
     @redises.set(@key, 'foobar')
   end
 
   it 'gets the number of set bits from the key' do
-    @redises.bitcount(@key).should == 26
+    expect(@redises.bitcount(@key)).to eq(26)
   end
 
   it 'gets the number of set bits from the key in an interval' do
-    @redises.bitcount(@key, 0, 1000).should == 26
-    @redises.bitcount(@key, 0, 0).should == 4
-    @redises.bitcount(@key, 1, 1).should == 6
-    @redises.bitcount(@key, 1, -2).should == 18
+    expect(@redises.bitcount(@key, 0, 1000)).to eq(26)
+    expect(@redises.bitcount(@key, 0, 0)).to eq(4)
+    expect(@redises.bitcount(@key, 1, 1)).to eq(6)
+    expect(@redises.bitcount(@key, 1, -2)).to eq(18)
   end
 
   it 'treats nonexistent keys as empty strings' do
-    @redises.bitcount('mock-redis-test:not-found').should == 0
+    expect(@redises.bitcount('mock-redis-test:not-found')).to eq(0)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/bitfield_spec.rb
+++ b/spec/commands/bitfield_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#bitfield(*args)' do
+RSpec.describe '#bitfield(*args)' do
   before :each do
     @key = 'mock-redis-test:bitfield'
     @redises.set(@key, '')
@@ -14,21 +14,21 @@ describe '#bitfield(*args)' do
 
   context 'with a :get command' do
     it 'gets a signed 8 bit value' do
-      @redises.bitfield(@key, :get, 'i8', 0).should == [78]
-      @redises.bitfield(@key, :get, 'i8', 8).should == [104]
-      @redises.bitfield(@key, :get, 'i8', 16).should == [-59]
+      expect(@redises.bitfield(@key, :get, 'i8', 0)).to eq([78])
+      expect(@redises.bitfield(@key, :get, 'i8', 8)).to eq([104])
+      expect(@redises.bitfield(@key, :get, 'i8', 16)).to eq([-59])
     end
 
     it 'gets multiple values with multiple command args' do
-      @redises.bitfield(@key, :get, 'i8', 0,
+      expect(@redises.bitfield(@key, :get, 'i8', 0,
                               :get, 'i8', 8,
-                              :get, 'i8', 16).should == [78, 104, -59]
+                              :get, 'i8', 16)).to eq([78, 104, -59])
     end
 
     it 'gets multiple values using positional offsets' do
-      @redises.bitfield(@key, :get, 'i8', '#0',
+      expect(@redises.bitfield(@key, :get, 'i8', '#0',
                               :get, 'i8', '#1',
-                              :get, 'i8', '#2').should == [78, 104, -59]
+                              :get, 'i8', '#2')).to eq([78, 104, -59])
     end
 
     it 'shows an error with an invalid type' do
@@ -49,94 +49,94 @@ describe '#bitfield(*args)' do
 
   context 'with a :set command' do
     it 'sets the bit values for an 8 bit signed integer' do
-      @redises.bitfield(@key, :set, 'i8', 0, 63).should == [78]
-      @redises.bitfield(@key, :set, 'i8', 8, -1).should == [104]
-      @redises.bitfield(@key, :set, 'i8', 16, 123).should == [-59]
+      expect(@redises.bitfield(@key, :set, 'i8', 0, 63)).to eq([78])
+      expect(@redises.bitfield(@key, :set, 'i8', 8, -1)).to eq([104])
+      expect(@redises.bitfield(@key, :set, 'i8', 16, 123)).to eq([-59])
 
-      @redises.bitfield(@key, :get, 'i8', 0,
+      expect(@redises.bitfield(@key, :get, 'i8', 0,
                               :get, 'i8', 8,
-                              :get, 'i8', 16).should == [63, -1, 123]
+                              :get, 'i8', 16)).to eq([63, -1, 123])
     end
 
     it 'sets multiple values with multiple command args' do
-      @redises.bitfield(@key, :set, 'i8', 0, 63,
+      expect(@redises.bitfield(@key, :set, 'i8', 0, 63,
                               :set, 'i8', 8, -1,
-                              :set, 'i8', 16, 123).should == [78, 104, -59]
+                              :set, 'i8', 16, 123)).to eq([78, 104, -59])
 
-      @redises.bitfield(@key, :get, 'i8', 0,
+      expect(@redises.bitfield(@key, :get, 'i8', 0,
                               :get, 'i8', 8,
-                              :get, 'i8', 16).should == [63, -1, 123]
+                              :get, 'i8', 16)).to eq([63, -1, 123])
     end
   end
 
   context 'with an :incrby command' do
     it 'returns the incremented by value for an 8 bit signed integer' do
-      @redises.bitfield(@key, :incrby, 'i8', 0, 1).should == [79]
-      @redises.bitfield(@key, :incrby, 'i8', 8, -1).should == [103]
-      @redises.bitfield(@key, :incrby, 'i8', 16, 5).should == [-54]
+      expect(@redises.bitfield(@key, :incrby, 'i8', 0, 1)).to eq([79])
+      expect(@redises.bitfield(@key, :incrby, 'i8', 8, -1)).to eq([103])
+      expect(@redises.bitfield(@key, :incrby, 'i8', 16, 5)).to eq([-54])
     end
 
     context 'with an overflow of wrap (default)' do
       context 'for a signed integer' do
         it 'wraps the overflow to the minimum and increments from there' do
-          @redises.bitfield(@key, :get, 'i8', 24).should == [78]
-          @redises.bitfield(@key, :overflow, :wrap,
-                                  :incrby, 'i8', 0, 200).should == [22]
+          expect(@redises.bitfield(@key, :get, 'i8', 24)).to eq([78])
+          expect(@redises.bitfield(@key, :overflow, :wrap,
+                                  :incrby, 'i8', 0, 200)).to eq([22])
         end
 
         it 'wraps the underflow to the maximum value and decrements from there' do
-          @redises.bitfield(@key, :overflow, :wrap,
-                                  :incrby, 'i8', 16, -200).should == [-3]
+          expect(@redises.bitfield(@key, :overflow, :wrap,
+                                  :incrby, 'i8', 16, -200)).to eq([-3])
         end
       end
 
       context 'for an unsigned integer' do
         it 'wraps the overflow back to zero and increments from there' do
-          @redises.bitfield(@key, :get, 'u8', 24).should == [78]
-          @redises.bitfield(@key, :overflow, :wrap,
-                                  :incrby, 'u8', 24, 233).should == [55]
+          expect(@redises.bitfield(@key, :get, 'u8', 24)).to eq([78])
+          expect(@redises.bitfield(@key, :overflow, :wrap,
+                                  :incrby, 'u8', 24, 233)).to eq([55])
         end
 
         it 'wraps the underflow to the maximum value and decrements from there' do
-          @redises.bitfield(@key, :get, 'u8', 32).should == [84]
-          @redises.bitfield(@key, :overflow, :wrap,
-                                  :incrby, 'u8', 32, -233).should == [107]
+          expect(@redises.bitfield(@key, :get, 'u8', 32)).to eq([84])
+          expect(@redises.bitfield(@key, :overflow, :wrap,
+                                  :incrby, 'u8', 32, -233)).to eq([107])
         end
       end
     end
 
     context 'with an overflow of sat' do
       it 'sets the overflowed value to the maximum' do
-        @redises.bitfield(@key, :overflow, :sat,
-                                :incrby, 'i8', 0, 256).should == [127]
+        expect(@redises.bitfield(@key, :overflow, :sat,
+                                :incrby, 'i8', 0, 256)).to eq([127])
       end
 
       it 'sets the underflowed value to the minimum' do
-        @redises.bitfield(@key, :overflow, :sat,
-                                :incrby, 'i8', 16, -256).should == [-128]
+        expect(@redises.bitfield(@key, :overflow, :sat,
+                                :incrby, 'i8', 16, -256)).to eq([-128])
       end
     end
 
     context 'with an overflow of fail' do
       it 'raises a redis error on an out of range value' do
-        @redises.bitfield(@key, :overflow, :fail,
-                                :incrby, 'i8', 0, 256).should == [nil]
+        expect(@redises.bitfield(@key, :overflow, :fail,
+                                :incrby, 'i8', 0, 256)).to eq([nil])
 
-        @redises.bitfield(@key, :overflow, :fail,
-                                :incrby, 'i8', 16, -256).should == [nil]
+        expect(@redises.bitfield(@key, :overflow, :fail,
+                                :incrby, 'i8', 16, -256)).to eq([nil])
       end
 
       it 'retains the original value after a failed increment' do
-        @redises.bitfield(@key, :get, 'i8', 0).should == [78]
-        @redises.bitfield(@key, :overflow, :fail,
-                                :incrby, 'i8', 0, 256).should == [nil]
-        @redises.bitfield(@key, :get, 'i8', 0).should == [78]
+        expect(@redises.bitfield(@key, :get, 'i8', 0)).to eq([78])
+        expect(@redises.bitfield(@key, :overflow, :fail,
+                                :incrby, 'i8', 0, 256)).to eq([nil])
+        expect(@redises.bitfield(@key, :get, 'i8', 0)).to eq([78])
       end
     end
 
     context 'with multiple overflow commands in one transaction' do
       it 'handles the overflow values correctly' do
-        @redises.bitfield(@key, :overflow, :sat,
+        expect(@redises.bitfield(@key, :overflow, :sat,
                                 :incrby, 'i8', 0, 256,
                                 :incrby, 'i8', 8, -256,
                                 :overflow, :wrap,
@@ -144,7 +144,7 @@ describe '#bitfield(*args)' do
                                 :incrby, 'i8', 16, -200,
                                 :overflow, :fail,
                                 :incrby, 'i8', 0, 256,
-                                :incrby, 'i8', 16, -256).should == [127, -128, 71, -3, nil, nil]
+                                :incrby, 'i8', 16, -256)).to eq([127, -128, 71, -3, nil, nil])
       end
     end
 
@@ -160,10 +160,10 @@ describe '#bitfield(*args)' do
 
   context 'with a mixed set of commands' do
     it 'returns the correct outputs' do
-      @redises.bitfield(@key, :set, 'i8', 0, 38,
+      expect(@redises.bitfield(@key, :set, 'i8', 0, 38,
                               :set, 'i8', 8, -99,
                               :incrby, 'i8', 16, 1,
-                              :get, 'i8', 0).should == [78, 104, -58, 38]
+                              :get, 'i8', 0)).to eq([78, 104, -58, 38])
     end
   end
 end

--- a/spec/commands/blmove_spec.rb
+++ b/spec/commands/blmove_spec.rb
@@ -34,8 +34,15 @@ RSpec.describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
 
   context '[mock only]' do
     it 'ignores positive timeouts and returns nil' do
-      expect(@redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 1)).
-        to be_nil
+      expect(
+        @redises.mock.blmove(
+          'mock-redis-test:not-here',
+          @list1,
+          'left',
+          'right',
+          :timeout => 1
+        )
+      ).to be_nil
     end
 
     it 'ignores positive legacy timeouts and returns nil' do

--- a/spec/commands/blmove_spec.rb
+++ b/spec/commands/blmove_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
+RSpec.describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
   before do
     @list1 = 'mock-redis-test:blmove-list1'
     @list2 = 'mock-redis-test:blmove-list2'
@@ -13,20 +13,20 @@ describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
   end
 
   it 'returns the value moved' do
-    @redises.blmove(@list1, @list2, 'left', 'right').should == 'a'
+    expect(@redises.blmove(@list1, @list2, 'left', 'right')).to eq('a')
   end
 
   it 'takes the first element of source and appends it to destination' do
     @redises.blmove(@list1, @list2, 'left', 'right')
 
-    @redises.lrange(@list1, 0, -1).should == %w[b]
-    @redises.lrange(@list2, 0, -1).should == %w[x y a]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[b])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[x y a])
   end
 
   it 'raises an error on negative timeout' do
-    lambda do
+    expect do
       @redises.blmove(@list1, @list2, 'left', 'right', :timeout => -1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   let(:default_error) { RedisMultiplexer::MismatchedResponse }
@@ -34,19 +34,19 @@ describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
 
   context '[mock only]' do
     it 'ignores positive timeouts and returns nil' do
-      @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 1).
-        should be_nil
+      expect(@redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 1)).
+        to be_nil
     end
 
     it 'ignores positive legacy timeouts and returns nil' do
-      @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', 1).
-        should be_nil
+      expect(@redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', 1)).
+        to be_nil
     end
 
     it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
-      lambda do
+      expect do
         @redises.mock.blmove('mock-redis-test:not-here', @list1, 'left', 'right', :timeout => 0)
-      end.should raise_error(MockRedis::WouldBlock)
+      end.to raise_error(MockRedis::WouldBlock)
     end
   end
 end

--- a/spec/commands/blpop_spec.rb
+++ b/spec/commands/blpop_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#blpop(key [, key, ...,], timeout)' do
+RSpec.describe '#blpop(key [, key, ...,], timeout)' do
   before do
     @list1 = 'mock-redis-test:blpop1'
     @list2 = 'mock-redis-test:blpop2'
@@ -12,42 +12,43 @@ describe '#blpop(key [, key, ...,], timeout)' do
   end
 
   it 'returns [first-nonempty-list, popped-value]' do
-    @redises.blpop(@list1, @list2).should == [@list1, 'one']
+    expect(@redises.blpop(@list1, @list2)).to eq([@list1, 'one'])
   end
 
   it 'pops that value off the list' do
     @redises.blpop(@list1, @list2)
     @redises.blpop(@list1, @list2)
 
-    @redises.blpop(@list1, @list2).should == [@list2, 'ten']
+    expect(@redises.blpop(@list1, @list2)).to eq([@list2, 'ten'])
   end
 
   it 'ignores empty keys' do
-    @redises.blpop('mock-redis-test:not-here', @list1).should ==
+    expect(@redises.blpop('mock-redis-test:not-here', @list1)).to eq(
       [@list1, 'one']
+    )
   end
 
   it 'raises an error on negative timeout' do
-    lambda do
+    expect do
       @redises.blpop(@list1, @list2, :timeout => -1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'
 
   context '[mock only]' do
     it 'ignores positive timeouts and returns nil' do
-      @redises.mock.blpop('mock-redis-test:not-here', :timeout => 1).should be_nil
+      expect(@redises.mock.blpop('mock-redis-test:not-here', :timeout => 1)).to be_nil
     end
 
     it 'ignores positive legacy timeouts and returns nil' do
-      @redises.mock.blpop('mock-redis-test:not-here', 1).should be_nil
+      expect(@redises.mock.blpop('mock-redis-test:not-here', 1)).to be_nil
     end
 
     it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
-      lambda do
+      expect do
         @redises.mock.blpop('mock-redis-test:not-here', :timeout => 0)
-      end.should raise_error(MockRedis::WouldBlock)
+      end.to raise_error(MockRedis::WouldBlock)
     end
   end
 end

--- a/spec/commands/brpop_spec.rb
+++ b/spec/commands/brpop_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#brpop(key [, key, ...,], timeout)' do
+RSpec.describe '#brpop(key [, key, ...,], timeout)' do
   before do
     @list1 = 'mock-redis-test:brpop1'
     @list2 = 'mock-redis-test:brpop2'
@@ -12,18 +12,19 @@ describe '#brpop(key [, key, ...,], timeout)' do
   end
 
   it 'returns [first-nonempty-list, popped-value]' do
-    @redises.brpop(@list1, @list2).should == [@list1, 'two']
+    expect(@redises.brpop(@list1, @list2)).to eq([@list1, 'two'])
   end
 
   it 'pops that value off the list' do
     @redises.brpop(@list1, @list2)
     @redises.brpop(@list1, @list2)
-    @redises.brpop(@list1, @list2).should == [@list2, 'ten']
+    expect(@redises.brpop(@list1, @list2)).to eq([@list2, 'ten'])
   end
 
   it 'ignores empty keys' do
-    @redises.brpop('mock-redis-test:not-here', @list1).should ==
+    expect(@redises.brpop('mock-redis-test:not-here', @list1)).to eq(
       [@list1, 'two']
+    )
   end
 
   # TODO: Not sure how redis-rb is handling this but they're not raising an error
@@ -34,26 +35,26 @@ describe '#brpop(key [, key, ...,], timeout)' do
   # end
 
   it 'raises an error on negative timeout' do
-    lambda do
+    expect do
       @redises.brpop(@list1, @list2, :timeout => -1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'
 
   context '[mock only]' do
     it 'ignores positive timeouts and returns nil' do
-      @redises.mock.brpop('mock-redis-test:not-here', :timeout => 1).should be_nil
+      expect(@redises.mock.brpop('mock-redis-test:not-here', :timeout => 1)).to be_nil
     end
 
     it 'ignores positive legacy timeouts and returns nil' do
-      @redises.mock.brpop('mock-redis-test:not-here', 1).should be_nil
+      expect(@redises.mock.brpop('mock-redis-test:not-here', 1)).to be_nil
     end
 
     it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
-      lambda do
+      expect do
         @redises.mock.brpop('mock-redis-test:not-here', :timeout => 0)
-      end.should raise_error(MockRedis::WouldBlock)
+      end.to raise_error(MockRedis::WouldBlock)
     end
   end
 end

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'spec_helper'
 
-describe '#brpoplpush(source, destination, timeout)' do
+RSpec.describe '#brpoplpush(source, destination, timeout)' do
   before do
     @list1 = 'mock-redis-test:brpoplpush1'
     @list2 = 'mock-redis-test:brpoplpush2'
@@ -16,37 +16,37 @@ describe '#brpoplpush(source, destination, timeout)' do
 
   it 'takes the last element of source and prepends it to destination' do
     @redises.brpoplpush(@list1, @list2)
-    @redises.lrange(@list1, 0, -1).should == %w[A]
-    @redises.lrange(@list2, 0, -1).should == %w[B alpha beta]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[A])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[B alpha beta])
   end
 
   it 'returns the moved element' do
-    @redises.brpoplpush(@list1, @list2).should == 'B'
+    expect(@redises.brpoplpush(@list1, @list2)).to eq('B')
   end
 
   it 'raises an error on negative timeout' do
-    lambda do
+    expect do
       @redises.brpoplpush(@list1, @list2, :timeout => -1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'
 
   context '[mock only]' do
     it 'ignores positive timeouts and returns nil' do
-      @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 1).
-        should be_nil
+      expect(@redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 1)).
+        to be_nil
     end
 
     it 'ignores positive legacy timeouts and returns nil' do
-      @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1).
-        should be_nil
+      expect(@redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1)).
+        to be_nil
     end
 
     it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
-      lambda do
+      expect do
         @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, :timeout => 0)
-      end.should raise_error(MockRedis::WouldBlock)
+      end.to raise_error(MockRedis::WouldBlock)
     end
   end
 end

--- a/spec/commands/connected_spec.rb
+++ b/spec/commands/connected_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#connected? [mock only]' do
+RSpec.describe '#connected? [mock only]' do
   it 'returns true' do
-    @redises.mock.connected?.should == true
+    expect(@redises.mock.connected?).to eq(true)
   end
 end

--- a/spec/commands/connection_spec.rb
+++ b/spec/commands/connection_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe '#connection' do
   let(:redis) { @redises.mock }
 
   it 'returns the correct values' do
-    expect(redis.connection).to eq({
-      :host => '127.0.0.1',
-      :port => 6379,
-      :db => 0,
-      :id => 'redis://127.0.0.1:6379/0',
-      :location => '127.0.0.1:6379'
-    })
+    expect(redis.connection).to eq(
+      {
+        :host => '127.0.0.1',
+        :port => 6379,
+        :db => 0,
+        :id => 'redis://127.0.0.1:6379/0',
+        :location => '127.0.0.1:6379'
+      }
+    )
   end
 end

--- a/spec/commands/connection_spec.rb
+++ b/spec/commands/connection_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
-describe '#connection' do
+RSpec.describe '#connection' do
   let(:redis) { @redises.mock }
 
   it 'returns the correct values' do
-    redis.connection.should == {
+    expect(redis.connection).to eq({
       :host => '127.0.0.1',
       :port => 6379,
       :db => 0,
       :id => 'redis://127.0.0.1:6379/0',
       :location => '127.0.0.1:6379'
-    }
+    })
   end
 end

--- a/spec/commands/dbsize_spec.rb
+++ b/spec/commands/dbsize_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe '#dbsize [mock only]' do
+RSpec.describe '#dbsize [mock only]' do
   # mock only since we can't guarantee that the real Redis is empty
   before { @mock = @redises.mock }
 
   it 'returns 0 for an empty DB' do
-    @mock.dbsize.should == 0
+    expect(@mock.dbsize).to eq(0)
   end
 
   it 'returns the number of keys in the DB' do
@@ -13,6 +13,6 @@ describe '#dbsize [mock only]' do
     @mock.lpush('bar', 2)
     @mock.hset('baz', 3, 4)
 
-    @mock.dbsize.should == 3
+    expect(@mock.dbsize).to eq(3)
   end
 end

--- a/spec/commands/decr_spec.rb
+++ b/spec/commands/decr_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#decr(key)' do
+RSpec.describe '#decr(key)' do
   before { @key = 'mock-redis-test:46895' }
 
   it 'returns the value after the decrement' do
     @redises.set(@key, 2)
-    @redises.decr(@key).should == 1
+    expect(@redises.decr(@key)).to eq(1)
   end
 
   it 'treats a missing key like 0' do
-    @redises.decr(@key).should == -1
+    expect(@redises.decr(@key)).to eq(-1)
   end
 
   it 'decrements negative numbers' do
     @redises.set(@key, -10)
-    @redises.decr(@key).should == -11
+    expect(@redises.decr(@key)).to eq(-11)
   end
 
   it 'works multiple times' do
-    @redises.decr(@key).should == -1
-    @redises.decr(@key).should == -2
-    @redises.decr(@key).should == -3
+    expect(@redises.decr(@key)).to eq(-1)
+    expect(@redises.decr(@key)).to eq(-2)
+    expect(@redises.decr(@key)).to eq(-3)
   end
 
   it 'raises an error if the value does not look like an integer' do
     @redises.set(@key, 'minus one')
-    lambda do
+    expect do
       @redises.decr(@key)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/decrby_spec.rb
+++ b/spec/commands/decrby_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#decrby(key, decrement)' do
+RSpec.describe '#decrby(key, decrement)' do
   before { @key = 'mock-redis-test:43650' }
 
   it 'returns the value after the decrement' do
     @redises.set(@key, 4)
-    @redises.decrby(@key, 2).should == 2
+    expect(@redises.decrby(@key, 2)).to eq(2)
   end
 
   it 'treats a missing key like 0' do
-    @redises.decrby(@key, 2).should == -2
+    expect(@redises.decrby(@key, 2)).to eq(-2)
   end
 
   it 'decrements negative numbers' do
     @redises.set(@key, -10)
-    @redises.decrby(@key, 2).should == -12
+    expect(@redises.decrby(@key, 2)).to eq(-12)
   end
 
   it 'works multiple times' do
-    @redises.decrby(@key, 2).should == -2
-    @redises.decrby(@key, 2).should == -4
-    @redises.decrby(@key, 2).should == -6
+    expect(@redises.decrby(@key, 2)).to eq(-2)
+    expect(@redises.decrby(@key, 2)).to eq(-4)
+    expect(@redises.decrby(@key, 2)).to eq(-6)
   end
 
   it 'raises an error if the value does not look like an integer' do
     @redises.set(@key, 'one')
-    lambda do
+    expect do
       @redises.decrby(@key, 1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/del_spec.rb
+++ b/spec/commands/del_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#del(key [, key, ...])' do
+RSpec.describe '#del(key [, key, ...])' do
   before :all do
     sleep 1 - (Time.now.to_f % 1)
   end
@@ -15,18 +15,18 @@ describe '#del(key [, key, ...])' do
     @redises.set('mock-redis-test:1', 1)
     @redises.set('mock-redis-test:2', 1)
 
-    @redises.del(
+    expect(@redises.del(
       'mock-redis-test:1',
       'mock-redis-test:2',
       'mock-redis-test:other'
-    ).should == 2
+    )).to eq(2)
   end
 
   it 'actually removes the key' do
     @redises.set('mock-redis-test:1', 1)
     @redises.del('mock-redis-test:1')
 
-    @redises.get('mock-redis-test:1').should be_nil
+    expect(@redises.get('mock-redis-test:1')).to be_nil
   end
 
   it 'accepts an array of keys' do
@@ -35,12 +35,12 @@ describe '#del(key [, key, ...])' do
 
     @redises.del(%w[mock-redis-test:1 mock-redis-test:2])
 
-    @redises.get('mock-redis-test:1').should be_nil
-    @redises.get('mock-redis-test:2').should be_nil
+    expect(@redises.get('mock-redis-test:1')).to be_nil
+    expect(@redises.get('mock-redis-test:2')).to be_nil
   end
 
   it 'raises an error if an empty array is given' do
-    expect { @redises.del [] }.not_to raise_error Redis::CommandError
+    expect { @redises.del [] }.not_to raise_error
   end
 
   it 'removes a stream key' do

--- a/spec/commands/del_spec.rb
+++ b/spec/commands/del_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe '#del(key [, key, ...])' do
     @redises.set('mock-redis-test:1', 1)
     @redises.set('mock-redis-test:2', 1)
 
-    expect(@redises.del(
-      'mock-redis-test:1',
-      'mock-redis-test:2',
-      'mock-redis-test:other'
-    )).to eq(2)
+    expect(
+      @redises.del(
+        'mock-redis-test:1',
+        'mock-redis-test:2',
+        'mock-redis-test:other'
+      )
+    ).to eq(2)
   end
 
   it 'actually removes the key' do

--- a/spec/commands/disconnect_spec.rb
+++ b/spec/commands/disconnect_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#disconnect [mock only]' do
+RSpec.describe '#disconnect [mock only]' do
   it 'returns nil' do
-    @redises.mock.disconnect.should be_nil
+    expect(@redises.mock.disconnect).to be_nil
   end
 end

--- a/spec/commands/dump_spec.rb
+++ b/spec/commands/dump_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#dump(key)' do
+RSpec.describe '#dump(key)' do
   before do
     @key = 'mock-redis-test:45794'
     # These are mock-only, since our dump/restore implementations
@@ -9,11 +9,11 @@ describe '#dump(key)' do
   end
 
   it 'returns nil for keys that do not exist' do
-    @mock.dump(@key).should be_nil
+    expect(@mock.dump(@key)).to be_nil
   end
 
   it 'returns a serialized value for keys that do exist' do
     @mock.set(@key, '2')
-    @mock.dump(@key).should == Marshal.dump('2')
+    expect(@mock.dump(@key)).to eq(Marshal.dump('2'))
   end
 end

--- a/spec/commands/echo_spec.rb
+++ b/spec/commands/echo_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe '#echo(str)' do
+RSpec.describe '#echo(str)' do
   it 'returns its argument' do
-    @redises.echo('foo').should == 'foo'
+    expect(@redises.echo('foo')).to eq('foo')
   end
 
   it 'stringifies its argument' do
-    @redises.echo(1).should == '1'
+    expect(@redises.echo(1)).to eq('1')
   end
 end

--- a/spec/commands/eval_spec.rb
+++ b/spec/commands/eval_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#eval(*)' do
+RSpec.describe '#eval(*)' do
   it 'returns nothing' do
-    @redises.eval('return nil').should be_nil
+    expect(@redises.eval('return nil')).to be_nil
   end
 end

--- a/spec/commands/evalsha_spec.rb
+++ b/spec/commands/evalsha_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe '#evalsha(*)' do
+RSpec.describe '#evalsha(*)' do
   let(:script) { 'return nil' }
   let(:script_digest) { Digest::SHA1.hexdigest(script) }
 
   it 'returns nothing' do
-    @redises.evalsha(script_digest).should be_nil
+    expect(@redises.evalsha(script_digest)).to be_nil
   end
 end

--- a/spec/commands/exists_spec.rb
+++ b/spec/commands/exists_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#exists(*keys)' do
+RSpec.describe '#exists(*keys)' do
   before { @key1 = 'mock-redis-test:exists1' }
   before { @key2 = 'mock-redis-test:exists2' }
 
   it 'returns 0 for keys that do not exist' do
-    @redises.exists(@key1).should == 0
-    @redises.exists(@key1, @key2).should == 0
+    expect(@redises.exists(@key1)).to eq(0)
+    expect(@redises.exists(@key1, @key2)).to eq(0)
   end
 
   it 'returns 1 for keys that do exist' do
     @redises.set(@key1, 1)
-    @redises.exists(@key1).should == 1
+    expect(@redises.exists(@key1)).to eq(1)
   end
 
   it 'returns the count of all keys that exist' do
     @redises.set(@key1, 1)
     @redises.set(@key2, 1)
-    @redises.exists(@key1, @key2).should == 2
-    @redises.exists(@key1, @key2, 'does-not-exist').should == 2
+    expect(@redises.exists(@key1, @key2)).to eq(2)
+    expect(@redises.exists(@key1, @key2, 'does-not-exist')).to eq(2)
   end
 end
 
-describe '#exists?(*keys)' do
+RSpec.describe '#exists?(*keys)' do
   before { @key1 = 'mock-redis-test:exists1' }
   before { @key2 = 'mock-redis-test:exists2' }
 
   it 'returns false for keys that do not exist' do
-    @redises.exists?(@key1).should == false
-    @redises.exists?(@key1, @key2).should == false
+    expect(@redises.exists?(@key1)).to eq(false)
+    expect(@redises.exists?(@key1, @key2)).to eq(false)
   end
 
   it 'returns true for keys that do exist' do
     @redises.set(@key1, 1)
-    @redises.exists?(@key1).should == true
+    expect(@redises.exists?(@key1)).to eq(true)
   end
 
   it 'returns true if any keys exist' do
     @redises.set(@key2, 1)
-    @redises.exists?(@key1, @key2).should == true
+    expect(@redises.exists?(@key1, @key2)).to eq(true)
   end
 end

--- a/spec/commands/expire_spec.rb
+++ b/spec/commands/expire_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
-describe '#expire(key, seconds)' do
+RSpec.describe '#expire(key, seconds)' do
   before do
     @key = 'mock-redis-test:expire'
     @redises.set(@key, 'spork')
   end
 
   it 'returns true for a key that exists' do
-    @redises.expire(@key, 1).should == true
+    expect(@redises.expire(@key, 1)).to eq(true)
   end
 
   it 'returns false for a key that does not exist' do
-    @redises.expire('mock-redis-test:nonesuch', 1).should == false
+    expect(@redises.expire('mock-redis-test:nonesuch', 1)).to eq(false)
   end
 
   it 'removes a key immediately when seconds==0' do
     @redises.expire(@key, 0)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'raises an error if seconds is bogus' do
-    lambda do
+    expect do
       @redises.expire(@key, 'a couple minutes or so')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'stringifies key' do
-    @redises.expire(@key.to_sym, 9).should == true
+    expect(@redises.expire(@key.to_sym, 9)).to eq(true)
   end
 
   context '[mock only]' do
@@ -39,29 +39,29 @@ describe '#expire(key, seconds)' do
 
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it 'removes keys after enough time has passed' do
       @mock.expire(@key, 5)
-      Time.stub(:now).and_return(@now + 5)
-      @mock.get(@key).should be_nil
+      allow(Time).to receive(:now).and_return(@now + 5)
+      expect(@mock.get(@key)).to be_nil
     end
 
     it 'updates an existing expire time' do
       @mock.expire(@key, 5)
       @mock.expire(@key, 6)
 
-      Time.stub(:now).and_return(@now + 5)
-      @mock.get(@key).should_not be_nil
+      allow(Time).to receive(:now).and_return(@now + 5)
+      expect(@mock.get(@key)).not_to be_nil
     end
 
     it 'has millisecond precision' do
       @now = Time.at(@now.to_i + 0.5)
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
       @mock.expire(@key, 5)
-      Time.stub(:now).and_return(@now + 4.9)
-      @mock.get(@key).should_not be_nil
+      allow(Time).to receive(:now).and_return(@now + 4.9)
+      expect(@mock.get(@key)).not_to be_nil
     end
 
     context 'expirations on a deleted key' do
@@ -73,9 +73,9 @@ describe '#expire(key, seconds)' do
         @mock.del(@key)
         @mock.set(@key, 'string')
 
-        Time.stub(:now).and_return(@now + 2)
+        allow(Time).to receive(:now).and_return(@now + 2)
 
-        @mock.get(@key).should_not be_nil
+        expect(@mock.get(@key)).not_to be_nil
       end
 
       it 'cleans up the expiration once the key is gone (list)' do
@@ -85,9 +85,9 @@ describe '#expire(key, seconds)' do
 
         @mock.rpush(@key, 'coconuts')
 
-        Time.stub(:now).and_return(@now + 2)
+        allow(Time).to receive(:now).and_return(@now + 2)
 
-        @mock.lindex(@key, 0).should_not be_nil
+        expect(@mock.lindex(@key, 0)).not_to be_nil
       end
     end
 
@@ -100,11 +100,11 @@ describe '#expire(key, seconds)' do
         @mock.expire(@key, 5)
         @mock.expire(other_key, 10)
 
-        Time.stub(:now).and_return(@now + 5)
-        @mock.get(@key).should be_nil
+        allow(Time).to receive(:now).and_return(@now + 5)
+        expect(@mock.get(@key)).to be_nil
 
-        Time.stub(:now).and_return(@now + 10)
-        @mock.get(other_key).should be_nil
+        allow(Time).to receive(:now).and_return(@now + 10)
+        expect(@mock.get(other_key)).to be_nil
       end
     end
   end

--- a/spec/commands/expireat_spec.rb
+++ b/spec/commands/expireat_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
-describe '#expireat(key, timestamp)' do
+RSpec.describe '#expireat(key, timestamp)' do
   before do
     @key = 'mock-redis-test:expireat'
     @redises.set(@key, 'spork')
   end
 
   it 'returns true for a key that exists' do
-    @redises.expireat(@key, Time.now.to_i + 1).should == true
+    expect(@redises.expireat(@key, Time.now.to_i + 1)).to eq(true)
   end
 
   it 'returns false for a key that does not exist' do
-    @redises.expireat('mock-redis-test:nonesuch', Time.now.to_i + 1).should == false
+    expect(@redises.expireat('mock-redis-test:nonesuch', Time.now.to_i + 1)).to eq(false)
   end
 
   it 'removes a key immediately when timestamp is now' do
     @redises.expireat(@key, Time.now.to_i)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it "raises an error if you don't give it a Unix timestamp" do
-    lambda do
+    expect do
       @redises.expireat(@key, Time.now) # oops, forgot .to_i
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   context '[mock only]' do
@@ -35,13 +35,13 @@ describe '#expireat(key, timestamp)' do
 
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it 'removes keys after enough time has passed' do
       @mock.expireat(@key, @now.to_i + 5)
-      Time.stub(:now).and_return(@now + 5)
-      @mock.get(@key).should be_nil
+      allow(Time).to receive(:now).and_return(@now + 5)
+      expect(@mock.get(@key)).to be_nil
     end
   end
 end

--- a/spec/commands/flushall_spec.rb
+++ b/spec/commands/flushall_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe '#flushall [mock only]' do
+RSpec.describe '#flushall [mock only]' do
   # don't want to hurt things in the real redis that are outside our
   # namespace.
   before { @mock = @redises.mock }
   before { @key = 'mock-redis-test:select' }
 
   it "returns 'OK'" do
-    @mock.flushall.should == 'OK'
+    expect(@mock.flushall).to eq('OK')
   end
 
   it 'removes all keys in the current DB' do
@@ -15,7 +15,7 @@ describe '#flushall [mock only]' do
     @mock.lpush('k2', 'v2')
 
     @mock.flushall
-    @mock.keys('*').should == []
+    expect(@mock.keys('*')).to eq([])
   end
 
   it 'removes all keys in other DBs, too' do
@@ -25,7 +25,7 @@ describe '#flushall [mock only]' do
     @mock.flushall
     @mock.select(0)
 
-    @mock.get('k1').should be_nil
+    expect(@mock.get('k1')).to be_nil
   end
 
   it 'removes expiration times' do
@@ -33,6 +33,6 @@ describe '#flushall [mock only]' do
     @mock.expire('k1', 360_000)
     @mock.flushall
     @mock.set('k1', 'v1')
-    @mock.ttl('k1').should == -1
+    expect(@mock.ttl('k1')).to eq(-1)
   end
 end

--- a/spec/commands/flushdb_spec.rb
+++ b/spec/commands/flushdb_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe '#flushdb [mock only]' do
+RSpec.describe '#flushdb [mock only]' do
   # don't want to hurt things in the real redis that are outside our
   # namespace.
   before { @mock = @redises.mock }
   before { @key = 'mock-redis-test:select' }
 
   it "returns 'OK'" do
-    @mock.flushdb.should == 'OK'
+    expect(@mock.flushdb).to eq('OK')
   end
 
   it 'removes all keys in the current DB' do
@@ -15,7 +15,7 @@ describe '#flushdb [mock only]' do
     @mock.lpush('k2', 'v2')
 
     @mock.flushdb
-    @mock.keys('*').should == []
+    expect(@mock.keys('*')).to eq([])
   end
 
   it 'leaves other databases alone' do
@@ -25,7 +25,7 @@ describe '#flushdb [mock only]' do
     @mock.flushdb
     @mock.select(0)
 
-    @mock.get('k1').should == 'v1'
+    expect(@mock.get('k1')).to eq('v1')
   end
 
   it 'removes expiration times' do
@@ -33,6 +33,6 @@ describe '#flushdb [mock only]' do
     @mock.expire('k1', 360_000)
     @mock.flushdb
     @mock.set('k1', 'v1')
-    @mock.ttl('k1').should == -1
+    expect(@mock.ttl('k1')).to eq(-1)
   end
 end

--- a/spec/commands/future_spec.rb
+++ b/spec/commands/future_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MockRedis::Future do
+RSpec.describe MockRedis::Future do
   let(:command) { [:get, 'foo'] }
   let(:result)  { 'bar' }
   let(:block)   { ->(value) { value.upcase } }
@@ -11,7 +11,7 @@ describe MockRedis::Future do
   end
 
   it 'remembers the command' do
-    @future.command.should eq(command)
+    expect(@future.command).to eq(command)
   end
 
   it 'raises an error if the value is requested before the result is set' do
@@ -20,11 +20,11 @@ describe MockRedis::Future do
 
   it 'returns the value after the result has been set' do
     @future.store_result(result)
-    @future.value.should eq(result)
+    expect(@future.value).to eq(result)
   end
 
   it 'executes the block on the value if block is passed in' do
     @future2.store_result(result)
-    @future2.value.should eq('BAR')
+    expect(@future2.value).to eq('BAR')
   end
 end

--- a/spec/commands/geoadd_spec.rb
+++ b/spec/commands/geoadd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#geoadd' do
+RSpec.describe '#geoadd' do
   let(:key) { 'cities' }
 
   context 'with valid points' do

--- a/spec/commands/geodist_spec.rb
+++ b/spec/commands/geodist_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-shared_examples 'a distance calculator' do
+RSpec.shared_examples 'a distance calculator' do
   it 'returns distance between two points in specified unit' do
     dist = @redises.geodist(key, 'SF', 'LA', unit)
     expect(dist).to be == expected_result
   end
 end
 
-describe '#geodist' do
+RSpec.describe '#geodist' do
   let(:key) { 'cities' }
 
   context 'with existing key' do

--- a/spec/commands/geohash_spec.rb
+++ b/spec/commands/geohash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#geohash' do
+RSpec.describe '#geohash' do
   let(:key) { 'cities' }
 
   context 'with existing key' do

--- a/spec/commands/geopos_spec.rb
+++ b/spec/commands/geopos_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#geopos' do
+RSpec.describe '#geopos' do
   let(:key) { 'cities' }
 
   context 'with existing key' do

--- a/spec/commands/get_spec.rb
+++ b/spec/commands/get_spec.rb
@@ -1,30 +1,30 @@
 require 'spec_helper'
 
-describe '#get(key)' do
+RSpec.describe '#get(key)' do
   before do
     @key = 'mock-redis-test:73288'
   end
 
   it 'returns nil for a nonexistent value' do
-    @redises.get('mock-redis-test:does-not-exist').should be_nil
+    expect(@redises.get('mock-redis-test:does-not-exist')).to be_nil
   end
 
   it 'returns a stored string value' do
     @redises.set(@key, 'forsooth')
-    @redises.get(@key).should == 'forsooth'
+    expect(@redises.get(@key)).to eq('forsooth')
   end
 
   it 'treats integers as strings' do
     @redises.set(@key, 100)
-    @redises.get(@key).should == '100'
+    expect(@redises.get(@key)).to eq('100')
   end
 
   it 'stringifies key' do
     key = :a_symbol
 
     @redises.set(key, 'hello')
-    @redises.get(key.to_s).should == 'hello'
-    @redises.get(key).should == 'hello'
+    expect(@redises.get(key.to_s)).to eq('hello')
+    expect(@redises.get(key)).to eq('hello')
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/getbit_spec.rb
+++ b/spec/commands/getbit_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#getbit(key, offset)' do
+RSpec.describe '#getbit(key, offset)' do
   before do
     @key = 'mock-redis-test:getbit'
     @redises.set(@key, 'h') # ASCII 0x68
   end
 
   it 'gets the bits from the key' do
-    @redises.getbit(@key, 0).should == 0
-    @redises.getbit(@key, 1).should == 1
-    @redises.getbit(@key, 2).should == 1
-    @redises.getbit(@key, 3).should == 0
-    @redises.getbit(@key, 4).should == 1
-    @redises.getbit(@key, 5).should == 0
-    @redises.getbit(@key, 6).should == 0
-    @redises.getbit(@key, 7).should == 0
+    expect(@redises.getbit(@key, 0)).to eq(0)
+    expect(@redises.getbit(@key, 1)).to eq(1)
+    expect(@redises.getbit(@key, 2)).to eq(1)
+    expect(@redises.getbit(@key, 3)).to eq(0)
+    expect(@redises.getbit(@key, 4)).to eq(1)
+    expect(@redises.getbit(@key, 5)).to eq(0)
+    expect(@redises.getbit(@key, 6)).to eq(0)
+    expect(@redises.getbit(@key, 7)).to eq(0)
   end
 
   it 'returns 0 for out-of-range bits' do
-    @redises.getbit(@key, 100).should == 0
+    expect(@redises.getbit(@key, 100)).to eq(0)
   end
 
   it 'does not modify the stored value for out-of-range bits' do
     @redises.getbit(@key, 100)
-    @redises.get(@key).should == 'h'
+    expect(@redises.get(@key)).to eq('h')
   end
 
   it 'treats nonexistent keys as empty strings' do
-    @redises.getbit('mock-redis-test:not-found', 0).should == 0
+    expect(@redises.getbit('mock-redis-test:not-found', 0)).to eq(0)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/getdel.rb
+++ b/spec/commands/getdel.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe '#getdel(key)' do
+RSpec.describe '#getdel(key)' do
   before do
     @key = 'mock-redis-test:73288'
   end
 
   it 'returns nil for a nonexistent value' do
-    @redises.getdel('mock-redis-test:does-not-exist').should be_nil
+    expect(@redises.getdel('mock-redis-test:does-not-exist')).to be_nil
   end
 
   it 'returns a stored string value' do
     @redises.set(@key, 'forsooth')
-    @redises.getdel(@key).should == 'forsooth'
+    expect(@redises.getdel(@key)).to eq('forsooth')
   end
 
   it 'deletes the key after returning it' do
     @redises.set(@key, 'forsooth')
     @redises.getdel(@key)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/getrange_spec.rb
+++ b/spec/commands/getrange_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
-describe '#getrange(key, start, stop)' do
+RSpec.describe '#getrange(key, start, stop)' do
   before do
     @key = 'mock-redis-test:getrange'
     @redises.set(@key, 'This is a string')
   end
 
   it 'returns a substring' do
-    @redises.getrange(@key, 0, 3).should == 'This'
+    expect(@redises.getrange(@key, 0, 3)).to eq('This')
   end
 
   it 'works with negative indices' do
-    @redises.getrange(@key, -3, -1).should == 'ing'
+    expect(@redises.getrange(@key, -3, -1)).to eq('ing')
   end
 
   it 'limits the result to the actual length of the string' do
-    @redises.getrange(@key, 10, 100).should == 'string'
+    expect(@redises.getrange(@key, 10, 100)).to eq('string')
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/getset_spec.rb
+++ b/spec/commands/getset_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 
-describe '#getrange(key, value)' do
+RSpec.describe '#getrange(key, value)' do
   before do
     @key = 'mock-redis-test:getset'
     @redises.set(@key, 'oldvalue')
   end
 
   it 'returns the old value' do
-    @redises.getset(@key, 'newvalue').should == 'oldvalue'
+    expect(@redises.getset(@key, 'newvalue')).to eq('oldvalue')
   end
 
   it 'sets the value to the new value' do
     @redises.getset(@key, 'newvalue')
-    @redises.get(@key).should == 'newvalue'
+    expect(@redises.get(@key)).to eq('newvalue')
   end
 
   it 'returns nil for nonexistent keys' do
-    @redises.getset('mock-redis-test:not-found', 1).should be_nil
+    expect(@redises.getset('mock-redis-test:not-found', 1)).to be_nil
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/hdel_spec.rb
+++ b/spec/commands/hdel_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hdel(key, field)' do
+RSpec.describe '#hdel(key, field)' do
   before do
     @key = 'mock-redis-test:hdel'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,62 +8,62 @@ describe '#hdel(key, field)' do
   end
 
   it 'returns 1 when it removes a field' do
-    @redises.hdel(@key, 'k1').should == 1
+    expect(@redises.hdel(@key, 'k1')).to eq(1)
   end
 
   it 'returns 0 when it does not remove a field' do
-    @redises.hdel(@key, 'nonesuch').should == 0
+    expect(@redises.hdel(@key, 'nonesuch')).to eq(0)
   end
 
   it 'actually removes the field' do
     @redises.hdel(@key, 'k1')
-    @redises.hget(@key, 'k1').should be_nil
+    expect(@redises.hget(@key, 'k1')).to be_nil
   end
 
   it 'treats the field as a string' do
     field = 2
     @redises.hset(@key, field, 'two')
     @redises.hdel(@key, field)
-    @redises.hget(@key, field).should be_nil
+    expect(@redises.hget(@key, field)).to be_nil
   end
 
   it 'removes only the field specified' do
     @redises.hdel(@key, 'k1')
-    @redises.hget(@key, 'k2').should == 'v2'
+    expect(@redises.hget(@key, 'k2')).to eq('v2')
   end
 
   it 'cleans up empty hashes' do
     @redises.hdel(@key, 'k1')
     @redises.hdel(@key, 'k2')
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'supports a variable number of arguments' do
     @redises.hdel(@key, 'k1', 'k2')
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'treats variable arguments as strings' do
     field = 2
     @redises.hset(@key, field, 'two')
     @redises.hdel(@key, field)
-    @redises.hget(@key, field).should be_nil
+    expect(@redises.hget(@key, field)).to be_nil
   end
 
   it 'supports a variable number of fields as array' do
-    @redises.hdel(@key, %w[k1 k2]).should == 2
+    expect(@redises.hdel(@key, %w[k1 k2])).to eq(2)
 
-    @redises.hget(@key, 'k1').should be_nil
-    @redises.hget(@key, 'k2').should be_nil
-    @redises.get(@key).should be_nil
+    expect(@redises.hget(@key, 'k1')).to be_nil
+    expect(@redises.hget(@key, 'k2')).to be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'supports a list of fields in various way' do
-    @redises.hdel(@key, ['k1'], 'k2').should == 2
+    expect(@redises.hdel(@key, ['k1'], 'k2')).to eq(2)
 
-    @redises.hget(@key, 'k1').should be_nil
-    @redises.hget(@key, 'k2').should be_nil
-    @redises.get(@key).should be_nil
+    expect(@redises.hget(@key, 'k1')).to be_nil
+    expect(@redises.hget(@key, 'k2')).to be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'raises error if an empty array is passed' do

--- a/spec/commands/hexists_spec.rb
+++ b/spec/commands/hexists_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
-describe '#hexists(key, field)' do
+RSpec.describe '#hexists(key, field)' do
   before do
     @key = 'mock-redis-test:hexists'
     @redises.hset(@key, 'field', 'value')
   end
 
   it 'returns true if the hash has that field' do
-    @redises.hexists(@key, 'field').should == true
+    expect(@redises.hexists(@key, 'field')).to eq(true)
   end
 
   it 'returns false if the hash lacks that field' do
-    @redises.hexists(@key, 'nonesuch').should == false
+    expect(@redises.hexists(@key, 'nonesuch')).to eq(false)
   end
 
   it 'treats the field as a string' do
     @redises.hset(@key, 1, 'one')
-    @redises.hexists(@key, 1).should == true
+    expect(@redises.hexists(@key, 1)).to eq(true)
   end
 
   it 'returns nil when there is no such key' do
-    @redises.hexists('mock-redis-test:nonesuch', 'key').should == false
+    expect(@redises.hexists('mock-redis-test:nonesuch', 'key')).to eq(false)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hget_spec.rb
+++ b/spec/commands/hget_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hget(key, field)' do
+RSpec.describe '#hget(key, field)' do
   before do
     @key = 'mock-redis-test:hget'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,20 +8,20 @@ describe '#hget(key, field)' do
   end
 
   it 'returns the value stored at field' do
-    @redises.hget(@key, 'k1').should == 'v1'
+    expect(@redises.hget(@key, 'k1')).to eq('v1')
   end
 
   it 'treats the field as a string' do
     @redises.hset(@key, '3', 'v3')
-    @redises.hget(@key, 3).should == 'v3'
+    expect(@redises.hget(@key, 3)).to eq('v3')
   end
 
   it 'returns nil when there is no such field' do
-    @redises.hget(@key, 'nonesuch').should be_nil
+    expect(@redises.hget(@key, 'nonesuch')).to be_nil
   end
 
   it 'returns nil when there is no such key' do
-    @redises.hget('mock-redis-test:nonesuch', 'k1').should be_nil
+    expect(@redises.hget('mock-redis-test:nonesuch', 'k1')).to be_nil
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hgetall_spec.rb
+++ b/spec/commands/hgetall_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe '#hgetall(key)' do
   end
 
   it 'returns the (key, value) pairs stored in the hash' do
-    expect(@redises.hgetall(@key)).to eq({
-      'k1' => 'v1',
-      'k2' => 'v2',
-    })
+    expect(@redises.hgetall(@key)).to eq(
+      {
+        'k1' => 'v1',
+        'k2' => 'v2',
+      }
+    )
   end
 
   it 'returns [] when there is no such key' do

--- a/spec/commands/hgetall_spec.rb
+++ b/spec/commands/hgetall_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hgetall(key)' do
+RSpec.describe '#hgetall(key)' do
   before do
     @key = 'mock-redis-test:hgetall'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,14 +8,14 @@ describe '#hgetall(key)' do
   end
 
   it 'returns the (key, value) pairs stored in the hash' do
-    @redises.hgetall(@key).should == {
+    expect(@redises.hgetall(@key)).to eq({
       'k1' => 'v1',
       'k2' => 'v2',
-    }
+    })
   end
 
   it 'returns [] when there is no such key' do
-    @redises.hgetall('mock-redis-test:nonesuch').should == {}
+    expect(@redises.hgetall('mock-redis-test:nonesuch')).to eq({})
   end
 
   it "doesn't return a mutable reference to the returned data" do
@@ -25,7 +25,7 @@ describe '#hgetall(key)' do
     hash = mr.hgetall(@key)
     hash['dont'] = 'mutate'
     new_hash = mr.hgetall(@key)
-    new_hash.keys.sort.should == %w[k1 k2]
+    expect(new_hash.keys.sort).to eq(%w[k1 k2])
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hincrby_spec.rb
+++ b/spec/commands/hincrby_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hincrby(key, field, increment)' do
+RSpec.describe '#hincrby(key, field, increment)' do
   before do
     @key = 'mock-redis-test:hincrby'
     @field = 'count'
@@ -8,50 +8,50 @@ describe '#hincrby(key, field, increment)' do
 
   it 'returns the value after the increment' do
     @redises.hset(@key, @field, 2)
-    @redises.hincrby(@key, @field, 2).should == 4
+    expect(@redises.hincrby(@key, @field, 2)).to eq(4)
   end
 
   it 'treats a missing key like 0' do
-    @redises.hincrby(@key, @field, 1).should == 1
+    expect(@redises.hincrby(@key, @field, 1)).to eq(1)
   end
 
   it 'creates a hash if nothing is present' do
     @redises.hincrby(@key, @field, 1)
-    @redises.hget(@key, @field).should == '1'
+    expect(@redises.hget(@key, @field)).to eq('1')
   end
 
   it 'increments negative numbers' do
     @redises.hset(@key, @field, -10)
-    @redises.hincrby(@key, @field, 2).should == -8
+    expect(@redises.hincrby(@key, @field, 2)).to eq(-8)
   end
 
   it 'works multiple times' do
-    @redises.hincrby(@key, @field, 2).should == 2
-    @redises.hincrby(@key, @field, 2).should == 4
-    @redises.hincrby(@key, @field, 2).should == 6
+    expect(@redises.hincrby(@key, @field, 2)).to eq(2)
+    expect(@redises.hincrby(@key, @field, 2)).to eq(4)
+    expect(@redises.hincrby(@key, @field, 2)).to eq(6)
   end
 
   it 'accepts an integer-ish string' do
-    @redises.hincrby(@key, @field, '2').should == 2
+    expect(@redises.hincrby(@key, @field, '2')).to eq(2)
   end
 
   it 'treats the field as a string' do
     field = 11
     @redises.hset(@key, field, 2)
-    @redises.hincrby(@key, field, 2).should == 4
+    expect(@redises.hincrby(@key, field, 2)).to eq(4)
   end
 
   it 'raises an error if the value does not look like an integer' do
     @redises.hset(@key, @field, 'one')
-    lambda do
+    expect do
       @redises.hincrby(@key, @field, 1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if the delta does not look like an integer' do
-    lambda do
+    expect do
       @redises.hincrby(@key, @field, 'foo')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hincrbyfloat_spec.rb
+++ b/spec/commands/hincrbyfloat_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hincrbyfloat(key, field, increment)' do
+RSpec.describe '#hincrbyfloat(key, field, increment)' do
   before do
     @key = 'mock-redis-test:hincrbyfloat'
     @field = 'count'
@@ -8,50 +8,50 @@ describe '#hincrbyfloat(key, field, increment)' do
 
   it 'returns the value after the increment' do
     @redises.hset(@key, @field, 2.0)
-    @redises.hincrbyfloat(@key, @field, 2.1).should be_within(0.0001).of(4.1)
+    expect(@redises.hincrbyfloat(@key, @field, 2.1)).to be_within(0.0001).of(4.1)
   end
 
   it 'treats a missing key like 0' do
-    @redises.hincrbyfloat(@key, @field, 1.2).should be_within(0.0001).of(1.2)
+    expect(@redises.hincrbyfloat(@key, @field, 1.2)).to be_within(0.0001).of(1.2)
   end
 
   it 'creates a hash if nothing is present' do
     @redises.hincrbyfloat(@key, @field, 1.0)
-    @redises.hget(@key, @field).should == '1'
+    expect(@redises.hget(@key, @field)).to eq('1')
   end
 
   it 'increments negative numbers' do
     @redises.hset(@key, @field, -10.4)
-    @redises.hincrbyfloat(@key, @field, 2.3).should be_within(0.0001).of(-8.1)
+    expect(@redises.hincrbyfloat(@key, @field, 2.3)).to be_within(0.0001).of(-8.1)
   end
 
   it 'works multiple times' do
-    @redises.hincrbyfloat(@key, @field, 2.1).should be_within(0.0001).of(2.1)
-    @redises.hincrbyfloat(@key, @field, 2.2).should be_within(0.0001).of(4.3)
-    @redises.hincrbyfloat(@key, @field, 2.3).should be_within(0.0001).of(6.6)
+    expect(@redises.hincrbyfloat(@key, @field, 2.1)).to be_within(0.0001).of(2.1)
+    expect(@redises.hincrbyfloat(@key, @field, 2.2)).to be_within(0.0001).of(4.3)
+    expect(@redises.hincrbyfloat(@key, @field, 2.3)).to be_within(0.0001).of(6.6)
   end
 
   it 'accepts a float-ish string' do
-    @redises.hincrbyfloat(@key, @field, '2.2').should be_within(0.0001).of(2.2)
+    expect(@redises.hincrbyfloat(@key, @field, '2.2')).to be_within(0.0001).of(2.2)
   end
 
   it 'treats the field as a string' do
     field = 11
     @redises.hset(@key, field, 2)
-    @redises.hincrbyfloat(@key, field, 2).should == 4.0
+    expect(@redises.hincrbyfloat(@key, field, 2)).to eq(4.0)
   end
 
   it 'raises an error if the value does not look like a float' do
     @redises.hset(@key, @field, 'one.two')
-    lambda do
+    expect do
       @redises.hincrbyfloat(@key, @field, 1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if the delta does not look like a float' do
-    lambda do
+    expect do
       @redises.hincrbyfloat(@key, @field, 'foobar.baz')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hkeys_spec.rb
+++ b/spec/commands/hkeys_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hkeys(key)' do
+RSpec.describe '#hkeys(key)' do
   before do
     @key = 'mock-redis-test:hkeys'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,11 +8,11 @@ describe '#hkeys(key)' do
   end
 
   it 'returns the keys stored in the hash' do
-    @redises.hkeys(@key).sort.should == %w[k1 k2]
+    expect(@redises.hkeys(@key).sort).to eq(%w[k1 k2])
   end
 
   it 'returns [] when there is no such key' do
-    @redises.hkeys('mock-redis-test:nonesuch').should == []
+    expect(@redises.hkeys('mock-redis-test:nonesuch')).to eq([])
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hlen_spec.rb
+++ b/spec/commands/hlen_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hlen(key)' do
+RSpec.describe '#hlen(key)' do
   before do
     @key = 'mock-redis-test:hlen'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,11 +8,11 @@ describe '#hlen(key)' do
   end
 
   it 'returns the number of keys stored in the hash' do
-    @redises.hlen(@key).should == 2
+    expect(@redises.hlen(@key)).to eq(2)
   end
 
   it 'returns [] when there is no such key' do
-    @redises.hlen('mock-redis-test:nonesuch').should == 0
+    expect(@redises.hlen('mock-redis-test:nonesuch')).to eq(0)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hmget_spec.rb
+++ b/spec/commands/hmget_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hmget(key, field [, field, ...])' do
+RSpec.describe '#hmget(key, field [, field, ...])' do
   before do
     @key = 'mock-redis-test:hmget'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,38 +8,38 @@ describe '#hmget(key, field [, field, ...])' do
   end
 
   it 'returns the values for those keys' do
-    @redises.hmget(@key, 'k1', 'k2').sort.should == %w[v1 v2]
+    expect(@redises.hmget(@key, 'k1', 'k2').sort).to eq(%w[v1 v2])
   end
 
   it 'treats an array as multiple keys' do
-    @redises.hmget(@key, %w[k1 k2]).sort.should == %w[v1 v2]
+    expect(@redises.hmget(@key, %w[k1 k2]).sort).to eq(%w[v1 v2])
   end
 
   it 'treats the fielsd as strings' do
     @redises.hset(@key, 1, 'one')
     @redises.hset(@key, 2, 'two')
-    @redises.hmget(@key, 1, 2).sort.should == %w[one two]
+    expect(@redises.hmget(@key, 1, 2).sort).to eq(%w[one two])
   end
 
   it 'returns nils when there are no such fields' do
-    @redises.hmget(@key, 'k1', 'mock-redis-test:nonesuch').
-      should == ['v1', nil]
+    expect(@redises.hmget(@key, 'k1', 'mock-redis-test:nonesuch')).
+      to eq(['v1', nil])
   end
 
   it 'returns nils when there is no such key' do
-    @redises.hmget(@key, 'mock-redis-test:nonesuch').should == [nil]
+    expect(@redises.hmget(@key, 'mock-redis-test:nonesuch')).to eq([nil])
   end
 
   it 'raises an error if given no fields' do
-    lambda do
+    expect do
       @redises.hmget(@key)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given an empty list of fields' do
-    lambda do
+    expect do
       @redises.hmget(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hmset_spec.rb
+++ b/spec/commands/hmset_spec.rb
@@ -1,42 +1,42 @@
 require 'spec_helper'
 
-describe '#hmset(key, field, value [, field, value ...])' do
+RSpec.describe '#hmset(key, field, value [, field, value ...])' do
   before do
     @key = 'mock-redis-test:hmset'
   end
 
   it "returns 'OK'" do
-    @redises.hmset(@key, 'k1', 'v1', 'k2', 'v2').should == 'OK'
+    expect(@redises.hmset(@key, 'k1', 'v1', 'k2', 'v2')).to eq('OK')
   end
 
   it 'sets the values' do
     @redises.hmset(@key, 'k1', 'v1', 'k2', 'v2')
-    @redises.hmget(@key, 'k1', 'k2').should == %w[v1 v2]
+    expect(@redises.hmget(@key, 'k1', 'k2')).to eq(%w[v1 v2])
   end
 
   it 'updates an existing hash' do
     @redises.hset(@key, 'foo', 'bar')
     @redises.hmset(@key, 'bert', 'ernie', 'diet', 'coke')
 
-    @redises.hmget(@key, 'foo', 'bert', 'diet').
-      should == %w[bar ernie coke]
+    expect(@redises.hmget(@key, 'foo', 'bert', 'diet')).
+      to eq(%w[bar ernie coke])
   end
 
   it 'stores the values as strings' do
     @redises.hmset(@key, 'one', 1)
-    @redises.hget(@key, 'one').should == '1'
+    expect(@redises.hget(@key, 'one')).to eq('1')
   end
 
   it 'raises an error if given no fields or values' do
-    lambda do
+    expect do
       @redises.hmset(@key)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given an odd number of fields+values' do
-    lambda do
+    expect do
       @redises.hmset(@key, 'k1', 1, 'k2')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   # The following tests address https://github.com/sds/mock_redis/issues/170
@@ -62,7 +62,7 @@ describe '#hmset(key, field, value [, field, value ...])' do
   # The following tests address https://github.com/sds/mock_redis/issues/134
   context 'hmset accepts an array as its only argument' do
     it { expect(@redises.hmset([@key, :bar, :bas])).to eq 'OK' }
-    it { lambda { @redises.hmset([:foo, :bar]) }.should raise_error(Redis::CommandError) }
+    it { expect { @redises.hmset([:foo, :bar]) }.to raise_error(Redis::CommandError) }
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hscan_each_spec.rb
+++ b/spec/commands/hscan_each_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hscan_each' do
+RSpec.describe '#hscan_each' do
   subject { MockRedis::Database.new(self) }
 
   let(:key) { 'mock-redis-test:hscan_each' }

--- a/spec/commands/hscan_spec.rb
+++ b/spec/commands/hscan_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hscan' do
+RSpec.describe '#hscan' do
   let(:count) { 10 }
   let(:match) { '*' }
   let(:key) { 'mock-redis-test:hscan' }

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -1,41 +1,41 @@
 require 'spec_helper'
 
-describe '#hset(key, field)' do
+RSpec.describe '#hset(key, field)' do
   before do
     @key = 'mock-redis-test:hset'
   end
 
   it 'returns 1 if the key does not exist' do
-    @redises.hset(@key, 'k1', 'v1').should == 1
+    expect(@redises.hset(@key, 'k1', 'v1')).to eq(1)
   end
 
   it 'returns 1 if the key exists but the field does not' do
     @redises.hset(@key, 'k1', 'v1')
-    @redises.hset(@key, 'k2', 'v2').should == 1
+    expect(@redises.hset(@key, 'k2', 'v2')).to eq(1)
   end
 
   it 'returns 0 if the field already exists' do
     @redises.hset(@key, 'k1', 'v1')
-    @redises.hset(@key, 'k1', 'v1').should == 0
+    expect(@redises.hset(@key, 'k1', 'v1')).to eq(0)
   end
 
   it 'creates a hash there is no such field' do
     @redises.hset(@key, 'k1', 'v1')
-    @redises.hget(@key, 'k1').should == 'v1'
+    expect(@redises.hget(@key, 'k1')).to eq('v1')
   end
 
   it 'stores values as strings' do
     @redises.hset(@key, 'num', 1)
-    @redises.hget(@key, 'num').should == '1'
+    expect(@redises.hget(@key, 'num')).to eq('1')
   end
 
   it 'stores fields as strings' do
     @redises.hset(@key, 1, 'one')
-    @redises.hget(@key, '1').should == 'one'
+    expect(@redises.hget(@key, '1')).to eq('one')
   end
 
   it 'stores fields sent in a hash' do
-    @redises.hset(@key, { 'k1' => 'v1', 'k2' => 'v2' }).should == 2
+    expect(@redises.hset(@key, { 'k1' => 'v1', 'k2' => 'v2' })).to eq(2)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hsetnx_spec.rb
+++ b/spec/commands/hsetnx_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#hsetnx(key, field)' do
+RSpec.describe '#hsetnx(key, field)' do
   before do
     @key = 'mock-redis-test:hsetnx'
   end
 
   it 'returns true if the field is absent' do
-    @redises.hsetnx(@key, 'field', 'val').should == true
+    expect(@redises.hsetnx(@key, 'field', 'val')).to eq(true)
   end
 
   it 'returns 0 if the field is present' do
     @redises.hset(@key, 'field', 'val')
-    @redises.hsetnx(@key, 'field', 'val').should == false
+    expect(@redises.hsetnx(@key, 'field', 'val')).to eq(false)
   end
 
   it 'leaves the field unchanged if the field is present' do
     @redises.hset(@key, 'field', 'old')
     @redises.hsetnx(@key, 'field', 'new')
-    @redises.hget(@key, 'field').should == 'old'
+    expect(@redises.hget(@key, 'field')).to eq('old')
   end
 
   it 'sets the field if the field is absent' do
     @redises.hsetnx(@key, 'field', 'new')
-    @redises.hget(@key, 'field').should == 'new'
+    expect(@redises.hget(@key, 'field')).to eq('new')
   end
 
   it 'creates a hash if there is no such field' do
     @redises.hsetnx(@key, 'field', 'val')
-    @redises.hget(@key, 'field').should == 'val'
+    expect(@redises.hget(@key, 'field')).to eq('val')
   end
 
   it 'stores values as strings' do
     @redises.hsetnx(@key, 'num', 1)
-    @redises.hget(@key, 'num').should == '1'
+    expect(@redises.hget(@key, 'num')).to eq('1')
   end
 
   it 'stores fields as strings' do
     @redises.hsetnx(@key, 1, 'one')
-    @redises.hget(@key, '1').should == 'one'
+    expect(@redises.hget(@key, '1')).to eq('one')
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hvals_spec.rb
+++ b/spec/commands/hvals_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hvals(key)' do
+RSpec.describe '#hvals(key)' do
   before do
     @key = 'mock-redis-test:hvals'
     @redises.hset(@key, 'k1', 'v1')
@@ -8,11 +8,11 @@ describe '#hvals(key)' do
   end
 
   it 'returns the values stored in the hash' do
-    @redises.hvals(@key).sort.should == %w[v1 v2]
+    expect(@redises.hvals(@key).sort).to eq(%w[v1 v2])
   end
 
   it 'returns [] when there is no such key' do
-    @redises.hvals('mock-redis-test:nonesuch').should == []
+    expect(@redises.hvals('mock-redis-test:nonesuch')).to eq([])
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/incr_spec.rb
+++ b/spec/commands/incr_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#incr(key)' do
+RSpec.describe '#incr(key)' do
   before { @key = 'mock-redis-test:33888' }
 
   it 'returns the value after the increment' do
     @redises.set(@key, 1)
-    @redises.incr(@key).should == 2
+    expect(@redises.incr(@key)).to eq(2)
   end
 
   it 'treats a missing key like 0' do
-    @redises.incr(@key).should == 1
+    expect(@redises.incr(@key)).to eq(1)
   end
 
   it 'increments negative numbers' do
     @redises.set(@key, -10)
-    @redises.incr(@key).should == -9
+    expect(@redises.incr(@key)).to eq(-9)
   end
 
   it 'works multiple times' do
-    @redises.incr(@key).should == 1
-    @redises.incr(@key).should == 2
-    @redises.incr(@key).should == 3
+    expect(@redises.incr(@key)).to eq(1)
+    expect(@redises.incr(@key)).to eq(2)
+    expect(@redises.incr(@key)).to eq(3)
   end
 
   it 'raises an error if the value does not look like an integer' do
     @redises.set(@key, 'one')
-    lambda do
+    expect do
       @redises.incr(@key)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/incrby_spec.rb
+++ b/spec/commands/incrby_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#incrby(key, increment)' do
+RSpec.describe '#incrby(key, increment)' do
   before { @key = 'mock-redis-test:65374' }
 
   it 'returns the value after the increment' do
     @redises.set(@key, 2)
-    @redises.incrby(@key, 2).should == 4
+    expect(@redises.incrby(@key, 2)).to eq(4)
   end
 
   it 'treats a missing key like 0' do
-    @redises.incrby(@key, 1).should == 1
+    expect(@redises.incrby(@key, 1)).to eq(1)
   end
 
   it 'increments negative numbers' do
     @redises.set(@key, -10)
-    @redises.incrby(@key, 2).should == -8
+    expect(@redises.incrby(@key, 2)).to eq(-8)
   end
 
   it 'works multiple times' do
-    @redises.incrby(@key, 2).should == 2
-    @redises.incrby(@key, 2).should == 4
-    @redises.incrby(@key, 2).should == 6
+    expect(@redises.incrby(@key, 2)).to eq(2)
+    expect(@redises.incrby(@key, 2)).to eq(4)
+    expect(@redises.incrby(@key, 2)).to eq(6)
   end
 
   it 'accepts an integer-ish string' do
-    @redises.incrby(@key, '2').should == 2
+    expect(@redises.incrby(@key, '2')).to eq(2)
   end
 
   it 'raises an error if the value does not look like an integer' do
     @redises.set(@key, 'one')
-    lambda do
+    expect do
       @redises.incrby(@key, 1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if the delta does not look like an integer' do
-    lambda do
+    expect do
       @redises.incrby(@key, 'foo')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/incrbyfloat_spec.rb
+++ b/spec/commands/incrbyfloat_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#incrbyfloat(key, increment)' do
+RSpec.describe '#incrbyfloat(key, increment)' do
   before { @key = 'mock-redis-test:65374' }
 
   it 'returns the value after the increment' do
     @redises.set(@key, 2.0)
-    @redises.incrbyfloat(@key, 2.1).should be_within(0.0001).of(4.1)
+    expect(@redises.incrbyfloat(@key, 2.1)).to be_within(0.0001).of(4.1)
   end
 
   it 'treats a missing key like 0' do
-    @redises.incrbyfloat(@key, 1.2).should be_within(0.0001).of(1.2)
+    expect(@redises.incrbyfloat(@key, 1.2)).to be_within(0.0001).of(1.2)
   end
 
   it 'increments negative numbers' do
     @redises.set(@key, -10.4)
-    @redises.incrbyfloat(@key, 2.3).should be_within(0.0001).of(-8.1)
+    expect(@redises.incrbyfloat(@key, 2.3)).to be_within(0.0001).of(-8.1)
   end
 
   it 'works multiple times' do
-    @redises.incrbyfloat(@key, 2.1).should be_within(0.0001).of(2.1)
-    @redises.incrbyfloat(@key, 2.2).should be_within(0.0001).of(4.3)
-    @redises.incrbyfloat(@key, 2.3).should be_within(0.0001).of(6.6)
+    expect(@redises.incrbyfloat(@key, 2.1)).to be_within(0.0001).of(2.1)
+    expect(@redises.incrbyfloat(@key, 2.2)).to be_within(0.0001).of(4.3)
+    expect(@redises.incrbyfloat(@key, 2.3)).to be_within(0.0001).of(6.6)
   end
 
   it 'accepts an float-ish string' do
-    @redises.incrbyfloat(@key, '2.2').should be_within(0.0001).of(2.2)
+    expect(@redises.incrbyfloat(@key, '2.2')).to be_within(0.0001).of(2.2)
   end
 
   it 'raises an error if the value does not look like an float' do
     @redises.set(@key, 'one.two')
-    lambda do
+    expect do
       @redises.incrbyfloat(@key, 1)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if the delta does not look like an float' do
-    lambda do
+    expect do
       @redises.incrbyfloat(@key, 'foobar.baz')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,62 +1,62 @@
 require 'spec_helper'
 
-describe '#info [mock only]' do
+RSpec.describe '#info [mock only]' do
   let(:redis) { @redises.mock }
 
   it 'responds with a config hash' do
-    redis.info.should be_a(Hash)
+    expect(redis.info).to be_a(Hash)
   end
 
   it 'gets default set of info' do
     info = redis.info
-    info['arch_bits'].should be_a(String)
-    info['connected_clients'].should be_a(String)
-    info['aof_rewrite_scheduled'].should be_a(String)
-    info['used_cpu_sys'].should be_a(String)
+    expect(info['arch_bits']).to be_a(String)
+    expect(info['connected_clients']).to be_a(String)
+    expect(info['aof_rewrite_scheduled']).to be_a(String)
+    expect(info['used_cpu_sys']).to be_a(String)
   end
 
   it 'gets all info' do
     info = redis.info(:all)
-    info['arch_bits'].should be_a(String)
-    info['connected_clients'].should be_a(String)
-    info['aof_rewrite_scheduled'].should be_a(String)
-    info['used_cpu_sys'].should be_a(String)
-    info['cmdstat_slowlog'].should be_a(String)
+    expect(info['arch_bits']).to be_a(String)
+    expect(info['connected_clients']).to be_a(String)
+    expect(info['aof_rewrite_scheduled']).to be_a(String)
+    expect(info['used_cpu_sys']).to be_a(String)
+    expect(info['cmdstat_slowlog']).to be_a(String)
   end
 
   it 'gets server info' do
-    redis.info(:server)['arch_bits'].should be_a(String)
+    expect(redis.info(:server)['arch_bits']).to be_a(String)
   end
 
   it 'gets clients info' do
-    redis.info(:clients)['connected_clients'].should be_a(String)
+    expect(redis.info(:clients)['connected_clients']).to be_a(String)
   end
 
   it 'gets memory info' do
-    redis.info(:memory)['used_memory'].should be_a(String)
+    expect(redis.info(:memory)['used_memory']).to be_a(String)
   end
 
   it 'gets persistence info' do
-    redis.info(:persistence)['aof_rewrite_scheduled'].should be_a(String)
+    expect(redis.info(:persistence)['aof_rewrite_scheduled']).to be_a(String)
   end
 
   it 'gets stats info' do
-    redis.info(:stats)['keyspace_hits'].should be_a(String)
+    expect(redis.info(:stats)['keyspace_hits']).to be_a(String)
   end
 
   it 'gets replication info' do
-    redis.info(:replication)['role'].should be_a(String)
+    expect(redis.info(:replication)['role']).to be_a(String)
   end
 
   it 'gets cpu info' do
-    redis.info(:cpu)['used_cpu_sys'].should be_a(String)
+    expect(redis.info(:cpu)['used_cpu_sys']).to be_a(String)
   end
 
   it 'gets keyspace info' do
-    redis.info(:keyspace)['db0'].should be_a(String)
+    expect(redis.info(:keyspace)['db0']).to be_a(String)
   end
 
   it 'gets commandstats info' do
-    redis.info(:commandstats)['sunionstore']['usec'].should be_a(String)
+    expect(redis.info(:commandstats)['sunionstore']['usec']).to be_a(String)
   end
 end

--- a/spec/commands/keys_spec.rb
+++ b/spec/commands/keys_spec.rb
@@ -34,39 +34,49 @@ RSpec.describe '#keys()' do
 
     describe 'the ? character' do
       it 'is treated as a single character (at the end of the pattern)' do
-        expect(@redises.keys('mock-redis-test:key?').sort).to eq([
-          'mock-redis-test:key1',
-          'mock-redis-test:key2',
-          'mock-redis-test:key3',
-        ])
+        expect(@redises.keys('mock-redis-test:key?').sort).to eq(
+          [
+            'mock-redis-test:key1',
+            'mock-redis-test:key2',
+            'mock-redis-test:key3',
+          ]
+        )
       end
 
       it 'is treated as a single character (in the middle of the pattern)' do
-        expect(@redises.keys('mock-redis-test:key?0').sort).to eq([
-          'mock-redis-test:key10',
-          'mock-redis-test:key20',
-          'mock-redis-test:key30',
-        ])
+        expect(@redises.keys('mock-redis-test:key?0').sort).to eq(
+          [
+            'mock-redis-test:key10',
+            'mock-redis-test:key20',
+            'mock-redis-test:key30',
+          ]
+        )
       end
 
       it 'treats \\? as a literal ?' do
-        expect(@redises.keys('mock-redis-test:special-key\?').sort).to eq([
-          'mock-redis-test:special-key?',
-        ])
+        expect(@redises.keys('mock-redis-test:special-key\?').sort).to eq(
+          [
+            'mock-redis-test:special-key?',
+          ]
+        )
       end
 
       context 'multiple ? characters' do
         it "properly handles multiple consequtive '?' characters" do
-          expect(@redises.keys('mock-redis-test:special-key-???').sort).to eq([
-            'mock-redis-test:special-key-!?*',
-          ])
+          expect(@redises.keys('mock-redis-test:special-key-???').sort).to eq(
+            [
+              'mock-redis-test:special-key-!?*',
+            ]
+          )
         end
 
         context '\\? as a literal ' do
           it 'handles multiple ? as both literal and special character' do
-            expect(@redises.keys('mock-redis-test:special-key-?\??').sort).to eq([
-              'mock-redis-test:special-key-!?*',
-            ])
+            expect(@redises.keys('mock-redis-test:special-key-?\??').sort).to eq(
+              [
+                'mock-redis-test:special-key-!?*',
+              ]
+            )
           end
         end
       end
@@ -74,65 +84,79 @@ RSpec.describe '#keys()' do
 
     describe 'the * character' do
       it 'is treated as 0 or more characters' do
-        expect(@redises.keys('mock-redis-test:key*').sort).to eq([
-          'mock-redis-test:key',
-          'mock-redis-test:key1',
-          'mock-redis-test:key10',
-          'mock-redis-test:key2',
-          'mock-redis-test:key20',
-          'mock-redis-test:key3',
-          'mock-redis-test:key30',
-        ])
+        expect(@redises.keys('mock-redis-test:key*').sort).to eq(
+          [
+            'mock-redis-test:key',
+            'mock-redis-test:key1',
+            'mock-redis-test:key10',
+            'mock-redis-test:key2',
+            'mock-redis-test:key20',
+            'mock-redis-test:key3',
+            'mock-redis-test:key30',
+          ]
+        )
       end
 
       it 'treats \\* as a literal *' do
-        expect(@redises.keys('mock-redis-test:special-key\*').sort).to eq([
-          'mock-redis-test:special-key*',
-        ])
+        expect(@redises.keys('mock-redis-test:special-key\*').sort).to eq(
+          [
+            'mock-redis-test:special-key*',
+          ]
+        )
       end
     end
 
     describe 'character classes ([abcde])' do
       it 'matches any one of those characters' do
-        expect(@redises.keys('mock-redis-test:key[12]').sort).to eq([
-          'mock-redis-test:key1',
-          'mock-redis-test:key2',
-        ])
+        expect(@redises.keys('mock-redis-test:key[12]').sort).to eq(
+          [
+            'mock-redis-test:key1',
+            'mock-redis-test:key2',
+          ]
+        )
       end
     end
 
     describe 'the | character' do
       it "is treated as literal (not 'or')" do
-        expect(@redises.keys('mock-redis-test:regexp-key(1|22)').sort).to eq([
-          'mock-redis-test:regexp-key(1|22)',
-        ])
+        expect(@redises.keys('mock-redis-test:regexp-key(1|22)').sort).to eq(
+          [
+            'mock-redis-test:regexp-key(1|22)',
+          ]
+        )
       end
     end
 
     describe 'the + character' do
       it "is treated as literal (not 'one or more' quantifier)" do
-        expect(@redises.keys('mock-redis-test:regexp-key3+').sort).to eq([
-          'mock-redis-test:regexp-key3+',
-        ])
+        expect(@redises.keys('mock-redis-test:regexp-key3+').sort).to eq(
+          [
+            'mock-redis-test:regexp-key3+',
+          ]
+        )
       end
     end
 
     describe 'character classes ([a-c])' do
       it 'specifies a range which matches any lowercase letter from "a" to "c"' do
-        expect(@redises.keys('mock-redis-test:regexp-key4[a-c]').sort).to eq([
-          'mock-redis-test:regexp-key4a',
-          'mock-redis-test:regexp-key4b',
-          'mock-redis-test:regexp-key4c',
-        ])
+        expect(@redises.keys('mock-redis-test:regexp-key4[a-c]').sort).to eq(
+          [
+            'mock-redis-test:regexp-key4a',
+            'mock-redis-test:regexp-key4b',
+            'mock-redis-test:regexp-key4c',
+          ]
+        )
       end
     end
 
     describe 'combining metacharacters' do
       it 'works with different metacharacters simultaneously' do
-        expect(@redises.keys('mock-redis-test:k*[12]?').sort).to eq([
-          'mock-redis-test:key10',
-          'mock-redis-test:key20',
-        ])
+        expect(@redises.keys('mock-redis-test:k*[12]?').sort).to eq(
+          [
+            'mock-redis-test:key10',
+            'mock-redis-test:key20',
+          ]
+        )
       end
     end
   end

--- a/spec/commands/keys_spec.rb
+++ b/spec/commands/keys_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe '#keys()' do
+RSpec.describe '#keys()' do
   it 'returns [] when no keys are found (no regex characters)' do
-    @redises.keys('mock-redis-test:29016').should == []
+    expect(@redises.keys('mock-redis-test:29016')).to eq([])
   end
 
   it 'returns [] when no keys are found (some regex characters)' do
-    @redises.keys('mock-redis-test:29016*').should == []
+    expect(@redises.keys('mock-redis-test:29016*')).to eq([])
   end
 
   describe 'with pattern matching' do
@@ -34,39 +34,39 @@ describe '#keys()' do
 
     describe 'the ? character' do
       it 'is treated as a single character (at the end of the pattern)' do
-        @redises.keys('mock-redis-test:key?').sort.should == [
+        expect(@redises.keys('mock-redis-test:key?').sort).to eq([
           'mock-redis-test:key1',
           'mock-redis-test:key2',
           'mock-redis-test:key3',
-        ]
+        ])
       end
 
       it 'is treated as a single character (in the middle of the pattern)' do
-        @redises.keys('mock-redis-test:key?0').sort.should == [
+        expect(@redises.keys('mock-redis-test:key?0').sort).to eq([
           'mock-redis-test:key10',
           'mock-redis-test:key20',
           'mock-redis-test:key30',
-        ]
+        ])
       end
 
       it 'treats \\? as a literal ?' do
-        @redises.keys('mock-redis-test:special-key\?').sort.should == [
+        expect(@redises.keys('mock-redis-test:special-key\?').sort).to eq([
           'mock-redis-test:special-key?',
-        ]
+        ])
       end
 
       context 'multiple ? characters' do
         it "properly handles multiple consequtive '?' characters" do
-          @redises.keys('mock-redis-test:special-key-???').sort.should == [
+          expect(@redises.keys('mock-redis-test:special-key-???').sort).to eq([
             'mock-redis-test:special-key-!?*',
-          ]
+          ])
         end
 
         context '\\? as a literal ' do
           it 'handles multiple ? as both literal and special character' do
-            @redises.keys('mock-redis-test:special-key-?\??').sort.should == [
+            expect(@redises.keys('mock-redis-test:special-key-?\??').sort).to eq([
               'mock-redis-test:special-key-!?*',
-            ]
+            ])
           end
         end
       end
@@ -74,7 +74,7 @@ describe '#keys()' do
 
     describe 'the * character' do
       it 'is treated as 0 or more characters' do
-        @redises.keys('mock-redis-test:key*').sort.should == [
+        expect(@redises.keys('mock-redis-test:key*').sort).to eq([
           'mock-redis-test:key',
           'mock-redis-test:key1',
           'mock-redis-test:key10',
@@ -82,57 +82,57 @@ describe '#keys()' do
           'mock-redis-test:key20',
           'mock-redis-test:key3',
           'mock-redis-test:key30',
-        ]
+        ])
       end
 
       it 'treats \\* as a literal *' do
-        @redises.keys('mock-redis-test:special-key\*').sort.should == [
+        expect(@redises.keys('mock-redis-test:special-key\*').sort).to eq([
           'mock-redis-test:special-key*',
-        ]
+        ])
       end
     end
 
     describe 'character classes ([abcde])' do
       it 'matches any one of those characters' do
-        @redises.keys('mock-redis-test:key[12]').sort.should == [
+        expect(@redises.keys('mock-redis-test:key[12]').sort).to eq([
           'mock-redis-test:key1',
           'mock-redis-test:key2',
-        ]
+        ])
       end
     end
 
     describe 'the | character' do
       it "is treated as literal (not 'or')" do
-        @redises.keys('mock-redis-test:regexp-key(1|22)').sort.should == [
+        expect(@redises.keys('mock-redis-test:regexp-key(1|22)').sort).to eq([
           'mock-redis-test:regexp-key(1|22)',
-        ]
+        ])
       end
     end
 
     describe 'the + character' do
       it "is treated as literal (not 'one or more' quantifier)" do
-        @redises.keys('mock-redis-test:regexp-key3+').sort.should == [
+        expect(@redises.keys('mock-redis-test:regexp-key3+').sort).to eq([
           'mock-redis-test:regexp-key3+',
-        ]
+        ])
       end
     end
 
     describe 'character classes ([a-c])' do
       it 'specifies a range which matches any lowercase letter from "a" to "c"' do
-        @redises.keys('mock-redis-test:regexp-key4[a-c]').sort.should == [
+        expect(@redises.keys('mock-redis-test:regexp-key4[a-c]').sort).to eq([
           'mock-redis-test:regexp-key4a',
           'mock-redis-test:regexp-key4b',
           'mock-redis-test:regexp-key4c',
-        ]
+        ])
       end
     end
 
     describe 'combining metacharacters' do
       it 'works with different metacharacters simultaneously' do
-        @redises.keys('mock-redis-test:k*[12]?').sort.should == [
+        expect(@redises.keys('mock-redis-test:k*[12]?').sort).to eq([
           'mock-redis-test:key10',
           'mock-redis-test:key20',
-        ]
+        ])
       end
     end
   end

--- a/spec/commands/lastsave_spec.rb
+++ b/spec/commands/lastsave_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe '#lastsave [mock only]' do
+RSpec.describe '#lastsave [mock only]' do
   # can't test against both since it's timing-dependent
   it 'returns a Unix time' do
-    @redises.mock.lastsave.to_s.should =~ /^\d+$/
+    expect(@redises.mock.lastsave.to_s).to match(/^\d+$/)
   end
 end

--- a/spec/commands/lindex_spec.rb
+++ b/spec/commands/lindex_spec.rb
@@ -1,48 +1,48 @@
 require 'spec_helper'
 
-describe '#lindex(key, index)' do
+RSpec.describe '#lindex(key, index)' do
   before { @key = 'mock-redis-test:69312' }
 
   it 'gets an element from the list by its index' do
     @redises.lpush(@key, 20)
     @redises.lpush(@key, 10)
 
-    @redises.lindex(@key, 0).should == '10'
-    @redises.lindex(@key, 1).should == '20'
+    expect(@redises.lindex(@key, 0)).to eq('10')
+    expect(@redises.lindex(@key, 1)).to eq('20')
   end
 
   it 'treats negative indices as coming from the right' do
     @redises.lpush(@key, 20)
     @redises.lpush(@key, 10)
 
-    @redises.lindex(@key, -1).should == '20'
-    @redises.lindex(@key, -2).should == '10'
+    expect(@redises.lindex(@key, -1)).to eq('20')
+    expect(@redises.lindex(@key, -2)).to eq('10')
   end
 
   it 'gets an element from the list by its index when index is a string' do
     @redises.lpush(@key, 20)
     @redises.lpush(@key, 10)
 
-    @redises.lindex(@key, '0').should == '10'
-    @redises.lindex(@key, '1').should == '20'
-    @redises.lindex(@key, '-1').should == '20'
-    @redises.lindex(@key, '-2').should == '10'
+    expect(@redises.lindex(@key, '0')).to eq('10')
+    expect(@redises.lindex(@key, '1')).to eq('20')
+    expect(@redises.lindex(@key, '-1')).to eq('20')
+    expect(@redises.lindex(@key, '-2')).to eq('10')
   end
 
   it 'returns nil if the index is too large (and positive)' do
     @redises.lpush(@key, 20)
 
-    @redises.lindex(@key, 100).should be_nil
+    expect(@redises.lindex(@key, 100)).to be_nil
   end
 
   it 'returns nil if the index is too large (and negative)' do
     @redises.lpush(@key, 20)
 
-    @redises.lindex(@key, -100).should be_nil
+    expect(@redises.lindex(@key, -100)).to be_nil
   end
 
   it 'returns nil for nonexistent values' do
-    @redises.lindex(@key, 0).should be_nil
+    expect(@redises.lindex(@key, 0)).to be_nil
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/linsert_spec.rb
+++ b/spec/commands/linsert_spec.rb
@@ -1,67 +1,67 @@
 require 'spec_helper'
 
-describe '#linsert(key, :before|:after, pivot, value)' do
+RSpec.describe '#linsert(key, :before|:after, pivot, value)' do
   before { @key = 'mock-redis-test:48733' }
 
   it 'returns the new size of the list when the pivot is found' do
     @redises.lpush(@key, 'X')
 
-    @redises.linsert(@key, :before, 'X', 'Y').should == 2
-    @redises.lpushx(@key, 'X').should == 3
+    expect(@redises.linsert(@key, :before, 'X', 'Y')).to eq(2)
+    expect(@redises.lpushx(@key, 'X')).to eq(3)
   end
 
   it 'does nothing when run against a nonexistent key' do
-    @redises.linsert(@key, :before, 1, 2).should == 0
-    @redises.get(@key).should be_nil
+    expect(@redises.linsert(@key, :before, 1, 2)).to eq(0)
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'returns -1 if the pivot is not found' do
     @redises.lpush(@key, 1)
-    @redises.linsert(@key, :after, 'X', 'Y').should == -1
+    expect(@redises.linsert(@key, :after, 'X', 'Y')).to eq(-1)
   end
 
   it 'inserts elements before the pivot when given :before as position' do
     @redises.lpush(@key, 'bert')
     @redises.linsert(@key, :before, 'bert', 'ernie')
 
-    @redises.lindex(@key, 0).should == 'ernie'
-    @redises.lindex(@key, 1).should == 'bert'
+    expect(@redises.lindex(@key, 0)).to eq('ernie')
+    expect(@redises.lindex(@key, 1)).to eq('bert')
   end
 
   it "inserts elements before the pivot when given 'before' as position" do
     @redises.lpush(@key, 'bert')
     @redises.linsert(@key, 'before', 'bert', 'ernie')
 
-    @redises.lindex(@key, 0).should == 'ernie'
-    @redises.lindex(@key, 1).should == 'bert'
+    expect(@redises.lindex(@key, 0)).to eq('ernie')
+    expect(@redises.lindex(@key, 1)).to eq('bert')
   end
 
   it 'inserts elements after the pivot when given :after as position' do
     @redises.lpush(@key, 'bert')
     @redises.linsert(@key, :after, 'bert', 'ernie')
 
-    @redises.lindex(@key, 0).should == 'bert'
-    @redises.lindex(@key, 1).should == 'ernie'
+    expect(@redises.lindex(@key, 0)).to eq('bert')
+    expect(@redises.lindex(@key, 1)).to eq('ernie')
   end
 
   it "inserts elements after the pivot when given 'after' as position" do
     @redises.lpush(@key, 'bert')
     @redises.linsert(@key, 'after', 'bert', 'ernie')
 
-    @redises.lindex(@key, 0).should == 'bert'
-    @redises.lindex(@key, 1).should == 'ernie'
+    expect(@redises.lindex(@key, 0)).to eq('bert')
+    expect(@redises.lindex(@key, 1)).to eq('ernie')
   end
 
   it 'raises an error when given a position that is neither before nor after' do
-    lambda do
+    expect do
       @redises.linsert(@key, :near, 1, 2)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'stores values as strings' do
     @redises.lpush(@key, 1)
     @redises.linsert(@key, :before, 1, 2)
-    @redises.lindex(@key, 0).should == '2'
+    expect(@redises.lindex(@key, 0)).to eq('2')
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/llen_spec.rb
+++ b/spec/commands/llen_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
-describe '#llen(key)' do
+RSpec.describe '#llen(key)' do
   before { @key = 'mock-redis-test:78407' }
 
   it 'returns 0 for a nonexistent key' do
-    @redises.llen(@key).should == 0
+    expect(@redises.llen(@key)).to eq(0)
   end
 
   it 'returns the length of the list' do
     5.times { @redises.lpush(@key, 'X') }
-    @redises.llen(@key).should == 5
+    expect(@redises.llen(@key)).to eq(5)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/lmove_spec.rb
+++ b/spec/commands/lmove_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#lmove(source, destination, wherefrom, whereto)' do
+RSpec.describe '#lmove(source, destination, wherefrom, whereto)' do
   before do
     @list1 = 'mock-redis-test:lmove-list1'
     @list2 = 'mock-redis-test:lmove-list2'
@@ -13,58 +13,58 @@ describe '#lmove(source, destination, wherefrom, whereto)' do
   end
 
   it 'returns the value moved' do
-    @redises.lmove(@list1, @list2, 'left', 'right').should == 'a'
+    expect(@redises.lmove(@list1, @list2, 'left', 'right')).to eq('a')
   end
 
   it "returns nil and doesn't append if source empty" do
-    @redises.lmove('empty', @list1, 'left', 'right').should be_nil
-    @redises.lrange(@list1, 0, -1).should == %w[a b]
+    expect(@redises.lmove('empty', @list1, 'left', 'right')).to be_nil
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[a b])
   end
 
   it 'takes the first element of source and prepends it to destination' do
     @redises.lmove(@list1, @list2, 'left', 'left')
 
-    @redises.lrange(@list1, 0, -1).should == %w[b]
-    @redises.lrange(@list2, 0, -1).should == %w[a x y]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[b])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[a x y])
   end
 
   it 'takes the first element of source and appends it to destination' do
     @redises.lmove(@list1, @list2, 'left', 'right')
 
-    @redises.lrange(@list1, 0, -1).should == %w[b]
-    @redises.lrange(@list2, 0, -1).should == %w[x y a]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[b])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[x y a])
   end
 
   it 'takes the last element of source and prepends it to destination' do
     @redises.lmove(@list1, @list2, 'right', 'left')
 
-    @redises.lrange(@list1, 0, -1).should == %w[a]
-    @redises.lrange(@list2, 0, -1).should == %w[b x y]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[a])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[b x y])
   end
 
   it 'takes the last element of source and appends it to destination' do
     @redises.lmove(@list1, @list2, 'right', 'right')
 
-    @redises.lrange(@list1, 0, -1).should == %w[a]
-    @redises.lrange(@list2, 0, -1).should == %w[x y b]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[a])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[x y b])
   end
 
   it 'rotates a list when source and destination are the same' do
     @redises.lmove(@list1, @list1, 'left', 'right')
-    @redises.lrange(@list1, 0, -1).should == %w[b a]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[b a])
   end
 
   it 'removes empty lists' do
     @redises.llen(@list1).times { @redises.lmove(@list1, @list2, 'left', 'right') }
-    @redises.get(@list1).should be_nil
+    expect(@redises.get(@list1)).to be_nil
   end
 
   it 'raises an error for non-list source value' do
     @redises.set(@list1, 'string value')
 
-    lambda do
+    expect do
       @redises.lmove(@list1, @list2, 'left', 'right')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   let(:default_error) { RedisMultiplexer::MismatchedResponse }

--- a/spec/commands/lpop_spec.rb
+++ b/spec/commands/lpop_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#lpop(key)' do
+RSpec.describe '#lpop(key)' do
   before { @key = 'mock-redis-test:65374' }
 
   it 'returns and removes the first element of a list' do
     @redises.lpush(@key, 1)
     @redises.lpush(@key, 2)
 
-    @redises.lpop(@key).should == '2'
+    expect(@redises.lpop(@key)).to eq('2')
 
-    @redises.llen(@key).should == 1
+    expect(@redises.llen(@key)).to eq(1)
   end
 
   it 'returns nil if the list is empty' do
     @redises.lpush(@key, 'foo')
     @redises.lpop(@key)
 
-    @redises.lpop(@key).should be_nil
+    expect(@redises.lpop(@key)).to be_nil
   end
 
   it 'returns nil for nonexistent values' do
-    @redises.lpop(@key).should be_nil
+    expect(@redises.lpop(@key)).to be_nil
   end
 
   it 'removes empty lists' do
     @redises.lpush(@key, 'foo')
     @redises.lpop(@key)
 
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   let(:default_error) { RedisMultiplexer::MismatchedResponse }

--- a/spec/commands/lpush_spec.rb
+++ b/spec/commands/lpush_spec.rb
@@ -1,42 +1,42 @@
 require 'spec_helper'
 
-describe '#lpush(key, value)' do
+RSpec.describe '#lpush(key, value)' do
   before { @key = 'mock-redis-test:57367' }
 
   it 'returns the new size of the list' do
-    @redises.lpush(@key, 'X').should == 1
-    @redises.lpush(@key, 'X').should == 2
+    expect(@redises.lpush(@key, 'X')).to eq(1)
+    expect(@redises.lpush(@key, 'X')).to eq(2)
   end
 
   it 'creates a new list when run against a nonexistent key' do
     @redises.lpush(@key, 'value')
-    @redises.llen(@key).should == 1
+    expect(@redises.llen(@key)).to eq(1)
   end
 
   it 'prepends items to the list' do
     @redises.lpush(@key, 'bert')
     @redises.lpush(@key, 'ernie')
 
-    @redises.lindex(@key, 0).should == 'ernie'
-    @redises.lindex(@key, 1).should == 'bert'
+    expect(@redises.lindex(@key, 0)).to eq('ernie')
+    expect(@redises.lindex(@key, 1)).to eq('bert')
   end
 
   it 'stores values as strings' do
     @redises.lpush(@key, 1)
-    @redises.lindex(@key, 0).should == '1'
+    expect(@redises.lindex(@key, 0)).to eq('1')
   end
 
   it 'supports a variable number of arguments' do
-    @redises.lpush(@key, [1, 2, 3]).should == 3
-    @redises.lindex(@key, 0).should == '3'
-    @redises.lindex(@key, 1).should == '2'
-    @redises.lindex(@key, 2).should == '1'
+    expect(@redises.lpush(@key, [1, 2, 3])).to eq(3)
+    expect(@redises.lindex(@key, 0)).to eq('3')
+    expect(@redises.lindex(@key, 1)).to eq('2')
+    expect(@redises.lindex(@key, 2)).to eq('1')
   end
 
   it 'raises an error if an empty array is given' do
-    lambda do
+    expect do
       @redises.lpush(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/lpushx_spec.rb
+++ b/spec/commands/lpushx_spec.rb
@@ -1,45 +1,45 @@
 require 'spec_helper'
 
-describe '#lpushx(key, value)' do
+RSpec.describe '#lpushx(key, value)' do
   before { @key = 'mock-redis-test:81267' }
 
   it 'returns the new size of the list' do
     @redises.lpush(@key, 'X')
 
-    @redises.lpushx(@key, 'X').should == 2
-    @redises.lpushx(@key, 'X').should == 3
+    expect(@redises.lpushx(@key, 'X')).to eq(2)
+    expect(@redises.lpushx(@key, 'X')).to eq(3)
   end
 
   it 'does nothing when run against a nonexistent key' do
     @redises.lpushx(@key, 'value')
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'prepends items to the list' do
     @redises.lpush(@key, 'bert')
     @redises.lpushx(@key, 'ernie')
 
-    @redises.lindex(@key, 0).should == 'ernie'
-    @redises.lindex(@key, 1).should == 'bert'
+    expect(@redises.lindex(@key, 0)).to eq('ernie')
+    expect(@redises.lindex(@key, 1)).to eq('bert')
   end
 
   it 'stores values as strings' do
     @redises.lpush(@key, 1)
     @redises.lpushx(@key, 2)
-    @redises.lindex(@key, 0).should == '2'
+    expect(@redises.lindex(@key, 0)).to eq('2')
   end
 
   it 'raises an error if an empty array is given' do
     @redises.lpush(@key, 'X')
-    lambda do
+    expect do
       @redises.lpushx(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'stores multiple items if an array of more than one item is given' do
     @redises.lpush(@key, 'X')
-    @redises.lpushx(@key, [1, 2]).should == 3
-    @redises.lrange(@key, 0, -1).should == %w[2 1 X]
+    expect(@redises.lpushx(@key, [1, 2])).to eq(3)
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[2 1 X])
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/lrange_spec.rb
+++ b/spec/commands/lrange_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#lrange(key, start, stop)' do
+RSpec.describe '#lrange(key, start, stop)' do
   before do
     @key = 'mock-redis-test:68036'
 
@@ -12,39 +12,39 @@ describe '#lrange(key, start, stop)' do
   end
 
   it 'returns a subset of the list inclusive of the right end' do
-    @redises.lrange(@key, 0, 2).should == %w[v0 v1 v2]
+    expect(@redises.lrange(@key, 0, 2)).to eq(%w[v0 v1 v2])
   end
 
   it 'returns a subset of the list when start and end are strings' do
-    @redises.lrange(@key, '0', '2').should == %w[v0 v1 v2]
+    expect(@redises.lrange(@key, '0', '2')).to eq(%w[v0 v1 v2])
   end
 
   it 'returns an empty list when start > end' do
-    @redises.lrange(@key, 3, 2).should == []
+    expect(@redises.lrange(@key, 3, 2)).to eq([])
   end
 
   it 'works with a negative stop index' do
-    @redises.lrange(@key, 2, -1).should == %w[v2 v3 v4]
+    expect(@redises.lrange(@key, 2, -1)).to eq(%w[v2 v3 v4])
   end
 
   it 'works with negative start and stop indices' do
-    @redises.lrange(@key, -2, -1).should == %w[v3 v4]
+    expect(@redises.lrange(@key, -2, -1)).to eq(%w[v3 v4])
   end
 
   it 'works with negative start indices less than list length' do
-    @redises.lrange(@key, -10, -2).should == %w[v0 v1 v2 v3]
+    expect(@redises.lrange(@key, -10, -2)).to eq(%w[v0 v1 v2 v3])
   end
 
   it 'returns [] when run against a nonexistent value' do
-    @redises.lrange('mock-redis-test:bogus-key', 0, 1).should == []
+    expect(@redises.lrange('mock-redis-test:bogus-key', 0, 1)).to eq([])
   end
 
   it 'returns [] when start is too large' do
-    @redises.lrange(@key, 100, 100).should == []
+    expect(@redises.lrange(@key, 100, 100)).to eq([])
   end
 
   it 'finds the end of the list correctly when end is too large' do
-    @redises.lrange(@key, 4, 10).should == %w[v4]
+    expect(@redises.lrange(@key, 4, 10)).to eq(%w[v4])
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/lrem_spec.rb
+++ b/spec/commands/lrem_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#lrem(key, count, value)' do
+RSpec.describe '#lrem(key, count, value)' do
   before do
     @key = 'mock-redis-test:66767'
 
@@ -16,55 +16,55 @@ describe '#lrem(key, count, value)' do
   it 'deletes the first count instances of key when count > 0' do
     @redises.lrem(@key, 2, 'bottles')
 
-    @redises.lrange(@key, 0, 8).should == %w[
+    expect(@redises.lrange(@key, 0, 8)).to eq(%w[
       99 of beer on the wall
       99 of beer
-    ]
+    ])
 
-    @redises.lrange(@key, -7, -1).should == %w[98 bottles of beer on the wall]
+    expect(@redises.lrange(@key, -7, -1)).to eq(%w[98 bottles of beer on the wall])
   end
 
   it 'deletes the last count instances of key when count < 0' do
     @redises.lrem(@key, -2, 'bottles')
 
-    @redises.lrange(@key, 0, 9).should == %w[
+    expect(@redises.lrange(@key, 0, 9)).to eq(%w[
       99 bottles of beer on the wall
       99 of beer
-    ]
+    ])
 
-    @redises.lrange(@key, -6, -1).should == %w[98 of beer on the wall]
+    expect(@redises.lrange(@key, -6, -1)).to eq(%w[98 of beer on the wall])
   end
 
   it 'deletes all instances of key when count == 0' do
     @redises.lrem(@key, 0, 'bottles')
-    @redises.lrange(@key, 0, -1).grep(/bottles/).should be_empty
+    expect(@redises.lrange(@key, 0, -1).grep(/bottles/)).to be_empty
   end
 
   it 'returns the number of elements deleted' do
-    @redises.lrem(@key, 2, 'bottles').should == 2
+    expect(@redises.lrem(@key, 2, 'bottles')).to eq(2)
   end
 
   it 'returns the number of elements deleted even if you ask for more' do
-    @redises.lrem(@key, 10, 'bottles').should == 3
+    expect(@redises.lrem(@key, 10, 'bottles')).to eq(3)
   end
 
   it 'stringifies value' do
-    @redises.lrem(@key, 0, 99).should == 2
+    expect(@redises.lrem(@key, 0, 99)).to eq(2)
   end
 
   it 'returns 0 when run against a nonexistent value' do
-    @redises.lrem('mock-redis-test:bogus-key', 0, 1).should == 0
+    expect(@redises.lrem('mock-redis-test:bogus-key', 0, 1)).to eq(0)
   end
 
   it 'returns 0 when run against an empty list' do
     @redises.llen(@key).times { @redises.lpop(@key) } # empty the list
-    @redises.lrem(@key, 0, 'beer').should == 0
+    expect(@redises.lrem(@key, 0, 'beer')).to eq(0)
   end
 
   it 'raises an error if the value does not look like an integer' do
-    lambda do
+    expect do
       @redises.lrem(@key, 'foo', 'bottles')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'removes empty lists' do
@@ -73,7 +73,7 @@ describe '#lrem(key, count, value)' do
     @redises.lpush(other_key, 'foo')
     @redises.lrem(other_key, 0, 'foo')
 
-    @redises.get(other_key).should be_nil
+    expect(@redises.get(other_key)).to be_nil
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/lrem_spec.rb
+++ b/spec/commands/lrem_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe '#lrem(key, count, value)' do
   it 'deletes the first count instances of key when count > 0' do
     @redises.lrem(@key, 2, 'bottles')
 
-    expect(@redises.lrange(@key, 0, 8)).to eq(%w[
-      99 of beer on the wall
-      99 of beer
-    ])
+    expect(@redises.lrange(@key, 0, 8)).to eq(
+      %w[
+        99 of beer on the wall
+        99 of beer
+      ]
+    )
 
     expect(@redises.lrange(@key, -7, -1)).to eq(%w[98 bottles of beer on the wall])
   end
@@ -27,10 +29,12 @@ RSpec.describe '#lrem(key, count, value)' do
   it 'deletes the last count instances of key when count < 0' do
     @redises.lrem(@key, -2, 'bottles')
 
-    expect(@redises.lrange(@key, 0, 9)).to eq(%w[
-      99 bottles of beer on the wall
-      99 of beer
-    ])
+    expect(@redises.lrange(@key, 0, 9)).to eq(
+      %w[
+        99 bottles of beer on the wall
+        99 of beer
+      ]
+    )
 
     expect(@redises.lrange(@key, -6, -1)).to eq(%w[98 of beer on the wall])
   end

--- a/spec/commands/lset_spec.rb
+++ b/spec/commands/lset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#lset(key, index, value)' do
+RSpec.describe '#lset(key, index, value)' do
   before do
     @key = 'mock-redis-test:21522'
 
@@ -9,34 +9,34 @@ describe '#lset(key, index, value)' do
   end
 
   it "returns 'OK'" do
-    @redises.lset(@key, 0, 'newthing').should == 'OK'
+    expect(@redises.lset(@key, 0, 'newthing')).to eq('OK')
   end
 
   it "sets the list's value at index to value" do
     @redises.lset(@key, 0, 'newthing')
-    @redises.lindex(@key, 0).should == 'newthing'
+    expect(@redises.lindex(@key, 0)).to eq('newthing')
   end
 
   it "sets the list's value at index to value when the index is a string" do
     @redises.lset(@key, '0', 'newthing')
-    @redises.lindex(@key, 0).should == 'newthing'
+    expect(@redises.lindex(@key, 0)).to eq('newthing')
   end
 
   it 'stringifies value' do
     @redises.lset(@key, 0, 12_345)
-    @redises.lindex(@key, 0).should == '12345'
+    expect(@redises.lindex(@key, 0)).to eq('12345')
   end
 
   it 'raises an exception for nonexistent keys' do
-    lambda do
+    expect do
       @redises.lset('mock-redis-test:bogus-key', 100, 'value')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an exception for out-of-range indices' do
-    lambda do
+    expect do
       @redises.lset(@key, 100, 'value')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/ltrim_spec.rb
+++ b/spec/commands/ltrim_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#ltrim(key, start, stop)' do
+RSpec.describe '#ltrim(key, start, stop)' do
   before do
     @key = 'mock-redis-test:22310'
 
@@ -8,37 +8,37 @@ describe '#ltrim(key, start, stop)' do
   end
 
   it "returns 'OK'" do
-    @redises.ltrim(@key, 1, 3).should == 'OK'
+    expect(@redises.ltrim(@key, 1, 3)).to eq('OK')
   end
 
   it 'trims the list to include only the specified elements' do
     @redises.ltrim(@key, 1, 3)
-    @redises.lrange(@key, 0, -1).should == %w[v1 v2 v3]
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[v1 v2 v3])
   end
 
   it 'trims the list when start and stop are strings' do
     @redises.ltrim(@key, '1', '3')
-    @redises.lrange(@key, 0, -1).should == %w[v1 v2 v3]
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[v1 v2 v3])
   end
 
   it 'trims the list to include only the specified elements (negative indices)' do
     @redises.ltrim(@key, -2, -1)
-    @redises.lrange(@key, 0, -1).should == %w[v3 v4]
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[v3 v4])
   end
 
   it 'trims the list to include only the specified elements (out of range negative indices)' do
     @redises.ltrim(@key, -10, -2)
-    @redises.lrange(@key, 0, -1).should == %w[v0 v1 v2 v3]
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[v0 v1 v2 v3])
   end
 
   it 'does not crash on overly-large indices' do
     @redises.ltrim(@key, 100, 200)
-    @redises.lrange(@key, 0, -1).should == %w[]
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[])
   end
 
   it 'removes empty lists' do
     @redises.ltrim(@key, 1, 0)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/mapped_hmget_spec.rb
+++ b/spec/commands/mapped_hmget_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
-describe '#mapped_hmget(key, *fields)' do
+RSpec.describe '#mapped_hmget(key, *fields)' do
   before do
     @key = 'mock-redis-test:mapped_hmget'
     @redises.hmset(@key, 'k1', 'v1', 'k2', 'v2')
   end
 
   it 'returns values stored at key' do
-    @redises.mapped_hmget(@key, 'k1', 'k2').should == { 'k1' => 'v1', 'k2' => 'v2' }
+    expect(@redises.mapped_hmget(@key, 'k1', 'k2')).to eq({ 'k1' => 'v1', 'k2' => 'v2' })
   end
 
   it 'returns nils for missing fields' do
-    @redises.mapped_hmget(@key, 'k1', 'mock-redis-test:nonesuch').
-      should == { 'k1' => 'v1', 'mock-redis-test:nonesuch' => nil }
+    expect(@redises.mapped_hmget(@key, 'k1', 'mock-redis-test:nonesuch')).
+      to eq({ 'k1' => 'v1', 'mock-redis-test:nonesuch' => nil })
   end
 
   it 'treats an array as the first key' do
-    @redises.mapped_hmget(@key, %w[k1 k2]).should == { %w[k1 k2] => 'v1' }
+    expect(@redises.mapped_hmget(@key, %w[k1 k2])).to eq({ %w[k1 k2] => 'v1' })
   end
 
   it 'raises an error if given no fields' do
-    lambda do
+    expect do
       @redises.mapped_hmget(@key)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/mapped_hmset_spec.rb
+++ b/spec/commands/mapped_hmset_spec.rb
@@ -1,47 +1,47 @@
 require 'spec_helper'
 
-describe '#mapped_hmset(key, hash={})' do
+RSpec.describe '#mapped_hmset(key, hash={})' do
   before do
     @key = 'mock-redis-test:mapped_hmset'
   end
 
   it "returns 'OK'" do
-    @redises.mapped_hmset(@key, 'k1' => 'v1', 'k2' => 'v2').should == 'OK'
+    expect(@redises.mapped_hmset(@key, 'k1' => 'v1', 'k2' => 'v2')).to eq('OK')
   end
 
   it 'sets the values' do
     @redises.mapped_hmset(@key, 'k1' => 'v1', 'k2' => 'v2')
-    @redises.hmget(@key, 'k1', 'k2').should == %w[v1 v2]
+    expect(@redises.hmget(@key, 'k1', 'k2')).to eq(%w[v1 v2])
   end
 
   it 'updates an existing hash' do
     @redises.hmset(@key, 'foo', 'bar')
     @redises.mapped_hmset(@key, 'bert' => 'ernie', 'diet' => 'coke')
 
-    @redises.hmget(@key, 'foo', 'bert', 'diet').
-      should == %w[bar ernie coke]
+    expect(@redises.hmget(@key, 'foo', 'bert', 'diet')).
+      to eq(%w[bar ernie coke])
   end
 
   it 'stores the values as strings' do
     @redises.mapped_hmset(@key, 'one' => 1)
-    @redises.hget(@key, 'one').should == '1'
+    expect(@redises.hget(@key, 'one')).to eq('1')
   end
 
   it 'raises an error if given no hash' do
-    lambda do
+    expect do
       @redises.mapped_hmset(@key)
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'raises an error if given a an odd length array' do
-    lambda do
+    expect do
       @redises.mapped_hmset(@key, [1])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given a non-hash value' do
-    lambda do
+    expect do
       @redises.mapped_hmset(@key, 1)
-    end.should raise_error(NoMethodError)
+    end.to raise_error(NoMethodError)
   end
 end

--- a/spec/commands/mapped_mget_spec.rb
+++ b/spec/commands/mapped_mget_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe '#mapped_mget(*keys)' do
   end
 
   it 'returns a hash' do
-    expect(@redises.mapped_mget(@key1, @key2, @key3)).to eq(@key1 => '1',
-                                                        @key2 => '2',
-                                                        @key3 => nil)
+    expect(@redises.mapped_mget(@key1, @key2, @key3)).to eq(
+      @key1 => '1',
+      @key2 => '2',
+      @key3 => nil
+    )
   end
 
   it 'returns a hash even when no matches' do

--- a/spec/commands/mapped_mget_spec.rb
+++ b/spec/commands/mapped_mget_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#mapped_mget(*keys)' do
+RSpec.describe '#mapped_mget(*keys)' do
   before do
     @key1 = 'mock-redis-test:a'
     @key2 = 'mock-redis-test:b'
@@ -11,12 +11,12 @@ describe '#mapped_mget(*keys)' do
   end
 
   it 'returns a hash' do
-    @redises.mapped_mget(@key1, @key2, @key3).should eq(@key1 => '1',
+    expect(@redises.mapped_mget(@key1, @key2, @key3)).to eq(@key1 => '1',
                                                         @key2 => '2',
                                                         @key3 => nil)
   end
 
   it 'returns a hash even when no matches' do
-    @redises.mapped_mget('qwer').should eq('qwer' => nil)
+    expect(@redises.mapped_mget('qwer')).to eq('qwer' => nil)
   end
 end

--- a/spec/commands/mapped_mset_spec.rb
+++ b/spec/commands/mapped_mset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#mapped_mset(hash)' do
+RSpec.describe '#mapped_mset(hash)' do
   before do
     @key1 = 'mock-redis-test:a'
     @key2 = 'mock-redis-test:b'
@@ -11,9 +11,9 @@ describe '#mapped_mset(hash)' do
   end
 
   it 'sets the values properly' do
-    @redises.mapped_mset(@key1 => 'one', @key3 => 'three').should eq('OK')
-    @redises.get(@key1).should eq('one')
-    @redises.get(@key2).should eq('2') # left alone
-    @redises.get(@key3).should eq('three')
+    expect(@redises.mapped_mset(@key1 => 'one', @key3 => 'three')).to eq('OK')
+    expect(@redises.get(@key1)).to eq('one')
+    expect(@redises.get(@key2)).to eq('2') # left alone
+    expect(@redises.get(@key3)).to eq('three')
   end
 end

--- a/spec/commands/mapped_msetnx_spec.rb
+++ b/spec/commands/mapped_msetnx_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#mapped_msetnx(hash)' do
+RSpec.describe '#mapped_msetnx(hash)' do
   before do
     @key1 = 'mock-redis-test:a'
     @key2 = 'mock-redis-test:b'
@@ -11,16 +11,16 @@ describe '#mapped_msetnx(hash)' do
   end
 
   it 'sets properly when none collide' do
-    @redises.mapped_msetnx(@key3 => 'three').should eq(true)
-    @redises.get(@key1).should eq('1') # existed; untouched
-    @redises.get(@key2).should eq('2') # existed; untouched
-    @redises.get(@key3).should eq('three')
+    expect(@redises.mapped_msetnx(@key3 => 'three')).to eq(true)
+    expect(@redises.get(@key1)).to eq('1') # existed; untouched
+    expect(@redises.get(@key2)).to eq('2') # existed; untouched
+    expect(@redises.get(@key3)).to eq('three')
   end
 
   it 'does not set any when any collide' do
-    @redises.mapped_msetnx(@key1 => 'one', @key3 => 'three').should eq(false)
-    @redises.get(@key1).should eq('1') # existed; untouched
-    @redises.get(@key2).should eq('2') # existed; untouched
-    @redises.get(@key3).should be_nil
+    expect(@redises.mapped_msetnx(@key1 => 'one', @key3 => 'three')).to eq(false)
+    expect(@redises.get(@key1)).to eq('1') # existed; untouched
+    expect(@redises.get(@key2)).to eq('2') # existed; untouched
+    expect(@redises.get(@key3)).to be_nil
   end
 end

--- a/spec/commands/mget_spec.rb
+++ b/spec/commands/mget_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#mget(key [, key, ...])' do
+RSpec.describe '#mget(key [, key, ...])' do
   before do
     @key1 = 'mock-redis-test:mget1'
     @key2 = 'mock-redis-test:mget2'
@@ -11,11 +11,11 @@ describe '#mget(key [, key, ...])' do
 
   context 'emulate param array' do
     it 'returns an array of values' do
-      @redises.mget([@key1, @key2]).should == %w[1 2]
+      expect(@redises.mget([@key1, @key2])).to eq(%w[1 2])
     end
 
     it 'returns an array of values' do
-      @redises.mget([@key1, @key2]).should == %w[1 2]
+      expect(@redises.mget([@key1, @key2])).to eq(%w[1 2])
     end
 
     it 'returns nil for non-string keys' do
@@ -23,17 +23,17 @@ describe '#mget(key [, key, ...])' do
 
       @redises.lpush(list, 'bork bork bork')
 
-      @redises.mget([@key1, @key2, list]).should == ['1', '2', nil]
+      expect(@redises.mget([@key1, @key2, list])).to eq(['1', '2', nil])
     end
   end
 
   context 'emulate params strings' do
     it 'returns an array of values' do
-      @redises.mget(@key1, @key2).should == %w[1 2]
+      expect(@redises.mget(@key1, @key2)).to eq(%w[1 2])
     end
 
     it 'returns nil for missing keys' do
-      @redises.mget(@key1, 'mock-redis-test:not-found', @key2).should == ['1', nil, '2']
+      expect(@redises.mget(@key1, 'mock-redis-test:not-found', @key2)).to eq(['1', nil, '2'])
     end
 
     it 'returns nil for non-string keys' do
@@ -41,25 +41,25 @@ describe '#mget(key [, key, ...])' do
 
       @redises.lpush(list, 'bork bork bork')
 
-      @redises.mget(@key1, @key2, list).should == ['1', '2', nil]
+      expect(@redises.mget(@key1, @key2, list)).to eq(['1', '2', nil])
     end
 
     it 'raises an error if you pass it 0 arguments' do
-      lambda do
+      expect do
         @redises.mget
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
 
     it 'raises an error if you pass it empty array' do
-      lambda do
+      expect do
         @redises.mget([])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
   context 'emulate block' do
     it 'returns an array of values' do
-      @redises.mget(@key1, @key2) { |values| values.map(&:to_i) }.should == [1, 2]
+      expect(@redises.mget(@key1, @key2) { |values| values.map(&:to_i) }).to eq([1, 2])
     end
   end
 end

--- a/spec/commands/move_spec.rb
+++ b/spec/commands/move_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#move(key, db)' do
+RSpec.describe '#move(key, db)' do
   before do
     @srcdb = 0
     @destdb = 1
@@ -17,16 +17,16 @@ describe '#move(key, db)' do
     end
 
     it 'returns false' do
-      @redises.move(@key, @destdb).should == false
+      expect(@redises.move(@key, @destdb)).to eq(false)
     end
 
     it 'leaves destdb/key alone' do
       @redises.select(@destdb)
-      @redises.get(@key).should == 'destvalue'
+      expect(@redises.get(@key)).to eq('destvalue')
     end
 
     it 'leaves srcdb/key alone' do
-      @redises.get(@key).should == 'srcvalue'
+      expect(@redises.get(@key)).to eq('srcvalue')
     end
   end
 
@@ -38,12 +38,12 @@ describe '#move(key, db)' do
     end
 
     it 'returns false' do
-      @redises.move(@key, @destdb).should == false
+      expect(@redises.move(@key, @destdb)).to eq(false)
     end
 
     it 'leaves destdb/key alone' do
       @redises.select(@destdb)
-      @redises.get(@key).should == 'destvalue'
+      expect(@redises.get(@key)).to eq('destvalue')
     end
   end
 
@@ -53,7 +53,7 @@ describe '#move(key, db)' do
     end
 
     it 'returns true' do
-      @redises.move(@key, @destdb).should == true
+      expect(@redises.move(@key, @destdb)).to eq(true)
     end
   end
 
@@ -64,12 +64,12 @@ describe '#move(key, db)' do
     end
 
     it 'removes key from srcdb' do
-      @redises.exists?(@key).should == false
+      expect(@redises.exists?(@key)).to eq(false)
     end
 
     it 'copies key to destdb' do
       @redises.select(@destdb)
-      @redises.get(@key).should == 'value'
+      expect(@redises.get(@key)).to eq('value')
     end
   end
 
@@ -81,12 +81,12 @@ describe '#move(key, db)' do
     end
 
     it 'removes key from srcdb' do
-      @redises.exists?(@key).should == false
+      expect(@redises.exists?(@key)).to eq(false)
     end
 
     it 'copies key to destdb' do
       @redises.select(@destdb)
-      @redises.lrange(@key, 0, -1).should == %w[bert ernie]
+      expect(@redises.lrange(@key, 0, -1)).to eq(%w[bert ernie])
     end
   end
 
@@ -99,12 +99,12 @@ describe '#move(key, db)' do
     end
 
     it 'removes key from srcdb' do
-      @redises.exists?(@key).should == false
+      expect(@redises.exists?(@key)).to eq(false)
     end
 
     it 'copies key to destdb' do
       @redises.select(@destdb)
-      @redises.hgetall(@key).should == { 'a' => '1', 'b' => '2' }
+      expect(@redises.hgetall(@key)).to eq({ 'a' => '1', 'b' => '2' })
     end
   end
 
@@ -117,12 +117,12 @@ describe '#move(key, db)' do
     end
 
     it 'removes key from srcdb' do
-      @redises.exists?(@key).should == false
+      expect(@redises.exists?(@key)).to eq(false)
     end
 
     it 'copies key to destdb' do
       @redises.select(@destdb)
-      @redises.smembers(@key).should == %w[wine beer]
+      expect(@redises.smembers(@key)).to eq(%w[wine beer])
     end
   end
 
@@ -135,13 +135,14 @@ describe '#move(key, db)' do
     end
 
     it 'removes key from srcdb' do
-      @redises.exists?(@key).should == false
+      expect(@redises.exists?(@key)).to eq(false)
     end
 
     it 'copies key to destdb' do
       @redises.select(@destdb)
-      @redises.zrange(@key, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@key, 0, -1, :with_scores => true)).to eq(
         [['beer', 1.0], ['wine', 2.0]]
+      )
     end
   end
 end

--- a/spec/commands/mset_spec.rb
+++ b/spec/commands/mset_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#mset(key, value [, key, value, ...])' do
+RSpec.describe '#mset(key, value [, key, value, ...])' do
   before do
     @key1 = 'mock-redis-test:mset1'
     @key2 = 'mock-redis-test:mset2'
   end
 
   it "responds with 'OK'" do
-    @redises.mset(@key1, 1).should == 'OK'
+    expect(@redises.mset(@key1, 1)).to eq('OK')
   end
 
   it "responds with 'OK' for passed Array with 1 item" do
-    @redises.mset([@key1, 1]).should == 'OK'
+    expect(@redises.mset([@key1, 1])).to eq('OK')
   end
 
   it "responds with 'OK' for passed Array with 2 items" do
-    @redises.mset([@key1, 1, @key2, 2]).should == 'OK'
+    expect(@redises.mset([@key1, 1, @key2, 2])).to eq('OK')
   end
 
   it 'sets the values' do
     @redises.mset(@key1, 'value1', @key2, 'value2')
-    @redises.mget(@key1, @key2).should == %w[value1 value2]
+    expect(@redises.mget(@key1, @key2)).to eq(%w[value1 value2])
   end
 
   it 'raises an error if given an odd number of arguments' do
-    lambda do
+    expect do
       @redises.mset(@key1, 'value1', @key2)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given 0 arguments' do
-    lambda do
+    expect do
       @redises.mset
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given odd-sized array' do
-    lambda do
+    expect do
       @redises.mset([@key1, 1, @key2])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/msetnx_spec.rb
+++ b/spec/commands/msetnx_spec.rb
@@ -1,40 +1,40 @@
 require 'spec_helper'
 
-describe '#msetnx(key, value [, key, value, ...])' do
+RSpec.describe '#msetnx(key, value [, key, value, ...])' do
   before do
     @key1 = 'mock-redis-test:msetnx1'
     @key2 = 'mock-redis-test:msetnx2'
   end
 
   it 'responds with 1 if any keys were set' do
-    @redises.msetnx(@key1, 1).should == true
+    expect(@redises.msetnx(@key1, 1)).to eq(true)
   end
 
   it 'sets the values' do
     @redises.msetnx(@key1, 'value1', @key2, 'value2')
-    @redises.mget(@key1, @key2).should == %w[value1 value2]
+    expect(@redises.mget(@key1, @key2)).to eq(%w[value1 value2])
   end
 
   it 'does nothing if any value is already set' do
     @redises.set(@key1, 'old1')
     @redises.msetnx(@key1, 'value1', @key2, 'value2')
-    @redises.mget(@key1, @key2).should == ['old1', nil]
+    expect(@redises.mget(@key1, @key2)).to eq(['old1', nil])
   end
 
   it 'responds with 0 if any value is already set' do
     @redises.set(@key1, 'old1')
-    @redises.msetnx(@key1, 'value1', @key2, 'value2').should == false
+    expect(@redises.msetnx(@key1, 'value1', @key2, 'value2')).to eq(false)
   end
 
   it 'raises an error if given an odd number of arguments' do
-    lambda do
+    expect do
       @redises.msetnx(@key1, 'value1', @key2)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if given 0 arguments' do
-    lambda do
+    expect do
       @redises.msetnx
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/persist_spec.rb
+++ b/spec/commands/persist_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#persist(key)' do
+RSpec.describe '#persist(key)' do
   before do
     @key = 'mock-redis-test:persist'
     @redises.set(@key, 'spork')
@@ -8,21 +8,21 @@ describe '#persist(key)' do
 
   it 'returns true for a key with a timeout' do
     @redises.expire(@key, 10_000)
-    @redises.persist(@key).should == true
+    expect(@redises.persist(@key)).to eq(true)
   end
 
   it 'returns false for a key with no timeout' do
-    @redises.persist(@key).should == false
+    expect(@redises.persist(@key)).to eq(false)
   end
 
   it 'returns false for a key that does not exist' do
-    @redises.persist('mock-redis-test:nonesuch').should == false
+    expect(@redises.persist('mock-redis-test:nonesuch')).to eq(false)
   end
 
   it 'removes the timeout' do
     @redises.expire(@key, 10_000)
     @redises.persist(@key)
-    @redises.persist(@key).should == false
+    expect(@redises.persist(@key)).to eq(false)
   end
 
   context '[mock only]' do
@@ -35,14 +35,14 @@ describe '#persist(key)' do
 
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it 'makes keys stay around' do
       @mock.expire(@key, 5)
       @mock.persist(@key)
-      Time.stub(:now).and_return(@now + 5)
-      @mock.get(@key).should_not be_nil
+      allow(Time).to receive(:now).and_return(@now + 5)
+      expect(@mock.get(@key)).not_to be_nil
     end
   end
 end

--- a/spec/commands/pexpire_spec.rb
+++ b/spec/commands/pexpire_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
-describe '#pexpire(key, ms)' do
+RSpec.describe '#pexpire(key, ms)' do
   before do
     @key = 'mock-redis-test:pexpire'
     @redises.set(@key, 'spork')
   end
 
   it 'returns true for a key that exists' do
-    @redises.pexpire(@key, 1).should == true
+    expect(@redises.pexpire(@key, 1)).to eq(true)
   end
 
   it 'returns false for a key that does not exist' do
-    @redises.pexpire('mock-redis-test:nonesuch', 1).should == false
+    expect(@redises.pexpire('mock-redis-test:nonesuch', 1)).to eq(false)
   end
 
   it 'removes a key immediately when ms==0' do
     @redises.pexpire(@key, 0)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'raises an error if ms is bogus' do
-    lambda do
+    expect do
       @redises.pexpire(@key, 'a couple minutes or so')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'stringifies key' do
-    @redises.pexpire(@key.to_sym, 9).should == true
+    expect(@redises.pexpire(@key.to_sym, 9)).to eq(true)
   end
 
   context '[mock only]' do
@@ -39,21 +39,21 @@ describe '#pexpire(key, ms)' do
 
     before do
       @now = Time.now.round
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it 'removes keys after enough time has passed' do
       @mock.pexpire(@key, 5)
-      Time.stub(:now).and_return(@now + Rational(6, 1000))
-      @mock.get(@key).should be_nil
+      allow(Time).to receive(:now).and_return(@now + Rational(6, 1000))
+      expect(@mock.get(@key)).to be_nil
     end
 
     it 'updates an existing pexpire time' do
       @mock.pexpire(@key, 5)
       @mock.pexpire(@key, 6)
 
-      Time.stub(:now).and_return(@now + Rational(5, 1000))
-      @mock.get(@key).should_not be_nil
+      allow(Time).to receive(:now).and_return(@now + Rational(5, 1000))
+      expect(@mock.get(@key)).not_to be_nil
     end
 
     context 'expirations on a deleted key' do
@@ -65,9 +65,9 @@ describe '#pexpire(key, ms)' do
         @mock.del(@key)
         @mock.set(@key, 'string')
 
-        Time.stub(:now).and_return(@now + 0.003)
+        allow(Time).to receive(:now).and_return(@now + 0.003)
 
-        @mock.get(@key).should_not be_nil
+        expect(@mock.get(@key)).not_to be_nil
       end
 
       it 'cleans up the expiration once the key is gone (list)' do
@@ -77,9 +77,9 @@ describe '#pexpire(key, ms)' do
 
         @mock.rpush(@key, 'coconuts')
 
-        Time.stub(:now).and_return(@now + 0.003)
+        allow(Time).to receive(:now).and_return(@now + 0.003)
 
-        @mock.lindex(@key, 0).should_not be_nil
+        expect(@mock.lindex(@key, 0)).not_to be_nil
       end
     end
   end

--- a/spec/commands/pexpireat_spec.rb
+++ b/spec/commands/pexpireat_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-describe '#pexpireat(key, timestamp_ms)' do
+RSpec.describe '#pexpireat(key, timestamp_ms)' do
   before do
     @key = 'mock-redis-test:pexpireat'
     @redises.set(@key, 'spork')
   end
 
   it 'returns true for a key that exists' do
-    @redises.pexpireat(@key, (Time.now.to_f * 1000).to_i + 1).should == true
+    expect(@redises.pexpireat(@key, (Time.now.to_f * 1000).to_i + 1)).to eq(true)
   end
 
   it 'returns false for a key that does not exist' do
-    @redises.pexpireat('mock-redis-test:nonesuch',
-                       (Time.now.to_f * 1000).to_i + 1).should == false
+    expect(@redises.pexpireat('mock-redis-test:nonesuch',
+                       (Time.now.to_f * 1000).to_i + 1)).to eq(false)
   end
 
   it 'removes a key immediately when timestamp is now' do
     @redises.pexpireat(@key, (Time.now.to_f * 1000).to_i)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it "raises an error if you don't give it a Unix timestamp" do
-    lambda do
+    expect do
       @redises.pexpireat(@key, Time.now) # oops, forgot .to_i
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   context '[mock only]' do
@@ -36,13 +36,13 @@ describe '#pexpireat(key, timestamp_ms)' do
 
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it 'removes keys after enough time has passed' do
       @mock.pexpireat(@key, (@now.to_f * 1000).to_i + 5)
-      Time.stub(:now).and_return(@now + 0.006)
-      @mock.get(@key).should be_nil
+      allow(Time).to receive(:now).and_return(@now + 0.006)
+      expect(@mock.get(@key)).to be_nil
     end
   end
 end

--- a/spec/commands/ping_spec.rb
+++ b/spec/commands/ping_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe '#ping' do
+RSpec.describe '#ping' do
   it 'returns "PONG" with no arguments' do
-    @redises.ping.should == 'PONG'
+    expect(@redises.ping).to eq('PONG')
   end
 
   it 'returns the argument' do
-    @redises.ping('HELLO').should == 'HELLO'
+    expect(@redises.ping('HELLO')).to eq('HELLO')
   end
 end

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe '#pipelined' do
+RSpec.describe '#pipelined' do
   it 'yields to its block' do
     res = false
     @redises.pipelined do
       res = true
     end
-    res.should == true
+    expect(res).to eq(true)
   end
 
   context 'with a few added data' do
@@ -26,7 +26,7 @@ describe '#pipelined' do
         redis.get key2
       end
 
-      results.should == [value1, value2]
+      expect(results).to eq([value1, value2])
     end
 
     it 'returns futures' do
@@ -36,7 +36,7 @@ describe '#pipelined' do
         future = redis.get key1
       end
 
-      future.class.should be MockRedis::Future
+      expect(future.class).to be MockRedis::Future
     end
   end
 
@@ -62,7 +62,7 @@ describe '#pipelined' do
         @redises.lrange(key2, 0, -1)
       end
 
-      results.should == [value1, value2]
+      expect(results).to eq([value1, value2])
     end
   end
 
@@ -108,7 +108,7 @@ describe '#pipelined' do
         end
       end
 
-      results.should == [value1, value2]
+      expect(results).to eq([value1, value2])
     end
   end
 end

--- a/spec/commands/psetex_spec.rb
+++ b/spec/commands/psetex_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-describe '#psetex(key, miliseconds, value)' do
+RSpec.describe '#psetex(key, miliseconds, value)' do
   before { @key = 'mock-redis-test:setex' }
 
   it "responds with 'OK'" do
-    @redises.psetex(@key, 10, 'value').should == 'OK'
+    expect(@redises.psetex(@key, 10, 'value')).to eq('OK')
   end
 
   it 'sets the value' do
     @redises.psetex(@key, 10_000, 'value')
-    @redises.get(@key).should == 'value'
+    expect(@redises.get(@key)).to eq('value')
   end
 
   it 'sets the expiration time' do
     @redises.psetex(@key, 10_000, 'value')
 
     # no guarantee these are the same
-    @redises.real.ttl(@key).should > 0
-    @redises.mock.ttl(@key).should > 0
+    expect(@redises.real.ttl(@key)).to be > 0
+    expect(@redises.mock.ttl(@key)).to be > 0
   end
 
   it 'converts time correctly' do
     @redises.psetex(@key, 10_000_000, 'value')
 
-    @redises.mock.ttl(@key).should > 9_000
+    expect(@redises.mock.ttl(@key)).to be > 9_000
   end
 
   context 'when expiration time is zero' do

--- a/spec/commands/pttl_spec.rb
+++ b/spec/commands/pttl_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe '#pttl(key)' do
+RSpec.describe '#pttl(key)' do
   before do
     @key = 'mock-redis-test:persist'
     @redises.set(@key, 'spork')
   end
 
   it 'returns -1 for a key with no expiration' do
-    @redises.pttl(@key).should == -1
+    expect(@redises.pttl(@key)).to eq(-1)
   end
 
   it 'returns -2 for a key that does not exist' do
-    @redises.pttl('mock-redis-test:nonesuch').should == -2
+    expect(@redises.pttl('mock-redis-test:nonesuch')).to eq(-2)
   end
 
   it 'stringifies key' do
     @redises.expire(@key, 8)
     # Don't check against Redis since millisecond timing differences are likely
-    @redises.send_without_checking(:pttl, @key.to_sym).should > 0
+    expect(@redises.send_without_checking(:pttl, @key.to_sym)).to be > 0
   end
 
   context '[mock only]' do
@@ -30,12 +30,12 @@ describe '#pttl(key)' do
 
     before do
       @now = Time.now.round
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it "gives you the key's remaining lifespan in milliseconds" do
       @mock.expire(@key, 5)
-      @mock.pttl(@key).should == 5000
+      expect(@mock.pttl(@key)).to eq(5000)
     end
   end
 end

--- a/spec/commands/quit_spec.rb
+++ b/spec/commands/quit_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#quit' do
+RSpec.describe '#quit' do
   it "responds with 'OK'" do
-    @redises.quit.should == 'OK'
+    expect(@redises.quit).to eq('OK')
   end
 end

--- a/spec/commands/randomkey_spec.rb
+++ b/spec/commands/randomkey_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#randomkey [mock only]' do
+RSpec.describe '#randomkey [mock only]' do
   before { @mock = @redises.mock }
 
   it 'finds a random key' do
@@ -10,11 +10,11 @@ describe '#randomkey [mock only]' do
       @mock.set(k, 1)
     end
 
-    @keys.should include(@mock.randomkey)
+    expect(@keys).to include(@mock.randomkey)
   end
 
   it 'returns nil when there are no keys' do
     @mock.keys('*').each { |k| @mock.del(k) }
-    @mock.randomkey.should be_nil
+    expect(@mock.randomkey).to be_nil
   end
 end

--- a/spec/commands/rename_spec.rb
+++ b/spec/commands/rename_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#rename(key, newkey)' do
+RSpec.describe '#rename(key, newkey)' do
   before do
     @key = 'mock-redis-test:rename:key'
     @newkey = 'mock-redis-test:rename:newkey'
@@ -9,34 +9,34 @@ describe '#rename(key, newkey)' do
   end
 
   it 'responds with "OK"' do
-    @redises.rename(@key, @newkey).should == 'OK'
+    expect(@redises.rename(@key, @newkey)).to eq('OK')
   end
 
   it 'moves the data' do
     @redises.rename(@key, @newkey)
-    @redises.get(@newkey).should == 'oof'
+    expect(@redises.get(@newkey)).to eq('oof')
   end
 
   it 'raises an error when the source key is nonexistant' do
     @redises.del(@key)
-    lambda do
+    expect do
       @redises.rename(@key, @newkey)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'responds with "OK" when key == newkey' do
-    @redises.rename(@key, @key).should == 'OK'
+    expect(@redises.rename(@key, @key)).to eq('OK')
   end
 
   it 'overwrites any existing value at newkey' do
     @redises.set(@newkey, 'rab')
     @redises.rename(@key, @newkey)
-    @redises.get(@newkey).should == 'oof'
+    expect(@redises.get(@newkey)).to eq('oof')
   end
 
   it 'keeps expiration' do
     @redises.expire(@key, 1000)
     @redises.rename(@key, @newkey)
-    @redises.ttl(@newkey).should be > 0
+    expect(@redises.ttl(@newkey)).to be > 0
   end
 end

--- a/spec/commands/renamenx_spec.rb
+++ b/spec/commands/renamenx_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#renamenx(key, newkey)' do
+RSpec.describe '#renamenx(key, newkey)' do
   before do
     @key = 'mock-redis-test:renamenx:key'
     @newkey = 'mock-redis-test:renamenx:newkey'
@@ -9,33 +9,33 @@ describe '#renamenx(key, newkey)' do
   end
 
   it 'responds with true when newkey does not exist' do
-    @redises.renamenx(@key, @newkey).should == true
+    expect(@redises.renamenx(@key, @newkey)).to eq(true)
   end
 
   it 'responds with false when newkey exists' do
     @redises.set(@newkey, 'monkey')
-    @redises.renamenx(@key, @newkey).should == false
+    expect(@redises.renamenx(@key, @newkey)).to eq(false)
   end
 
   it 'moves the data' do
     @redises.renamenx(@key, @newkey)
-    @redises.get(@newkey).should == 'oof'
+    expect(@redises.get(@newkey)).to eq('oof')
   end
 
   it 'raises an error when the source key is nonexistant' do
     @redises.del(@key)
-    lambda do
+    expect do
       @redises.rename(@key, @newkey)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'returns false when key == newkey' do
-    @redises.renamenx(@key, @key).should == false
+    expect(@redises.renamenx(@key, @key)).to eq(false)
   end
 
   it 'leaves any existing value at newkey alone' do
     @redises.set(@newkey, 'rab')
     @redises.renamenx(@key, @newkey)
-    @redises.get(@newkey).should == 'rab'
+    expect(@redises.get(@newkey)).to eq('rab')
   end
 end

--- a/spec/commands/restore_spec.rb
+++ b/spec/commands/restore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#restore(key, ttl, value)' do
+RSpec.describe '#restore(key, ttl, value)' do
   before do
     @key = 'mock-redis-test:45794'
     @src = MockRedis.new
@@ -8,7 +8,7 @@ describe '#restore(key, ttl, value)' do
     @dumped_value = @src.dump(@key)
     @dst = MockRedis.new
     @now = Time.now.round
-    Time.stub(:now).and_return(@now)
+    allow(Time).to receive(:now).and_return(@now)
   end
 
   it 'allows dump/restoring values between two redis instances' do

--- a/spec/commands/rpop_spec.rb
+++ b/spec/commands/rpop_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe '#rpop(key)' do
+RSpec.describe '#rpop(key)' do
   before { @key = 'mock-redis-test:43093' }
 
   it 'returns and removes the first element of a list' do
     @redises.lpush(@key, 1)
     @redises.lpush(@key, 2)
 
-    @redises.rpop(@key).should == '1'
+    expect(@redises.rpop(@key)).to eq('1')
 
-    @redises.llen(@key).should == 1
+    expect(@redises.llen(@key)).to eq(1)
   end
 
   it 'returns nil if the list is empty' do
     @redises.lpush(@key, 'foo')
     @redises.rpop(@key)
 
-    @redises.rpop(@key).should be_nil
+    expect(@redises.rpop(@key)).to be_nil
   end
 
   it 'returns nil for nonexistent values' do
-    @redises.rpop(@key).should be_nil
+    expect(@redises.rpop(@key)).to be_nil
   end
 
   it 'removes empty lists' do
     @redises.lpush(@key, 'foo')
     @redises.rpop(@key)
 
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   let(:default_error) { RedisMultiplexer::MismatchedResponse }

--- a/spec/commands/rpoplpush_spec.rb
+++ b/spec/commands/rpoplpush_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#rpoplpush(source, destination)' do
+RSpec.describe '#rpoplpush(source, destination)' do
   before do
     @list1 = 'mock-redis-test:rpoplpush-list1'
     @list2 = 'mock-redis-test:rpoplpush-list2'
@@ -13,37 +13,37 @@ describe '#rpoplpush(source, destination)' do
   end
 
   it 'returns the value moved' do
-    @redises.rpoplpush(@list1, @list2).should == 'b'
+    expect(@redises.rpoplpush(@list1, @list2)).to eq('b')
   end
 
   it "returns false and doesn't append if source empty" do
-    @redises.rpoplpush('empty', @list1).should be_nil
-    @redises.lrange(@list1, 0, -1).should == %w[a b]
+    expect(@redises.rpoplpush('empty', @list1)).to be_nil
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[a b])
   end
 
   it 'takes the last element of destination and prepends it to source' do
     @redises.rpoplpush(@list1, @list2)
 
-    @redises.lrange(@list1, 0, -1).should == %w[a]
-    @redises.lrange(@list2, 0, -1).should == %w[b x y]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[a])
+    expect(@redises.lrange(@list2, 0, -1)).to eq(%w[b x y])
   end
 
   it 'rotates a list when source and destination are the same' do
     @redises.rpoplpush(@list1, @list1)
-    @redises.lrange(@list1, 0, -1).should == %w[b a]
+    expect(@redises.lrange(@list1, 0, -1)).to eq(%w[b a])
   end
 
   it 'removes empty lists' do
     @redises.llen(@list1).times { @redises.rpoplpush(@list1, @list2) }
-    @redises.get(@list1).should be_nil
+    expect(@redises.get(@list1)).to be_nil
   end
 
   it 'raises an error for non-list source value' do
     @redises.set(@list1, 'string value')
 
-    lambda do
+    expect do
       @redises.rpoplpush(@list1, @list2)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/rpush_spec.rb
+++ b/spec/commands/rpush_spec.rb
@@ -1,42 +1,42 @@
 require 'spec_helper'
 
-describe '#rpush(key)' do
+RSpec.describe '#rpush(key)' do
   before { @key = "mock-redis-test:#{__FILE__}" }
 
   it 'returns the new size of the list' do
-    @redises.rpush(@key, 'X').should == 1
-    @redises.rpush(@key, 'X').should == 2
+    expect(@redises.rpush(@key, 'X')).to eq(1)
+    expect(@redises.rpush(@key, 'X')).to eq(2)
   end
 
   it 'creates a new list when run against a nonexistent key' do
     @redises.rpush(@key, 'value')
-    @redises.llen(@key).should == 1
+    expect(@redises.llen(@key)).to eq(1)
   end
 
   it 'appends items to the list' do
     @redises.rpush(@key, 'bert')
     @redises.rpush(@key, 'ernie')
 
-    @redises.lindex(@key, 0).should == 'bert'
-    @redises.lindex(@key, 1).should == 'ernie'
+    expect(@redises.lindex(@key, 0)).to eq('bert')
+    expect(@redises.lindex(@key, 1)).to eq('ernie')
   end
 
   it 'stores values as strings' do
     @redises.rpush(@key, 1)
-    @redises.lindex(@key, 0).should == '1'
+    expect(@redises.lindex(@key, 0)).to eq('1')
   end
 
   it 'supports a variable number of arguments' do
-    @redises.rpush(@key, [1, 2, 3]).should == 3
-    @redises.lindex(@key, 0).should == '1'
-    @redises.lindex(@key, 1).should == '2'
-    @redises.lindex(@key, 2).should == '3'
+    expect(@redises.rpush(@key, [1, 2, 3])).to eq(3)
+    expect(@redises.lindex(@key, 0)).to eq('1')
+    expect(@redises.lindex(@key, 1)).to eq('2')
+    expect(@redises.lindex(@key, 2)).to eq('3')
   end
 
   it 'raises an error if an empty array is given' do
-    lambda do
+    expect do
       @redises.rpush(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/rpushx_spec.rb
+++ b/spec/commands/rpushx_spec.rb
@@ -1,45 +1,45 @@
 require 'spec_helper'
 
-describe '#rpushx(key, value)' do
+RSpec.describe '#rpushx(key, value)' do
   before { @key = 'mock-redis-test:92925' }
 
   it 'returns the new size of the list' do
     @redises.lpush(@key, 'X')
 
-    @redises.rpushx(@key, 'X').should == 2
-    @redises.rpushx(@key, 'X').should == 3
+    expect(@redises.rpushx(@key, 'X')).to eq(2)
+    expect(@redises.rpushx(@key, 'X')).to eq(3)
   end
 
   it 'does nothing when run against a nonexistent key' do
     @redises.rpushx(@key, 'value')
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'appends items to the list' do
     @redises.lpush(@key, 'bert')
     @redises.rpushx(@key, 'ernie')
 
-    @redises.lindex(@key, 0).should == 'bert'
-    @redises.lindex(@key, 1).should == 'ernie'
+    expect(@redises.lindex(@key, 0)).to eq('bert')
+    expect(@redises.lindex(@key, 1)).to eq('ernie')
   end
 
   it 'stores values as strings' do
     @redises.rpush(@key, 1)
     @redises.rpushx(@key, 2)
-    @redises.lindex(@key, 1).should == '2'
+    expect(@redises.lindex(@key, 1)).to eq('2')
   end
 
   it 'raises an error if an empty array is given' do
     @redises.lpush(@key, 'X')
-    lambda do
+    expect do
       @redises.rpushx(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'stores multiple items if an array of more than one item is given' do
     @redises.lpush(@key, 'X')
-    @redises.rpushx(@key, [1, 2]).should == 3
-    @redises.lrange(@key, 0, -1).should == %w[X 1 2]
+    expect(@redises.rpushx(@key, [1, 2])).to eq(3)
+    expect(@redises.lrange(@key, 0, -1)).to eq(%w[X 1 2])
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -1,43 +1,43 @@
 require 'spec_helper'
 
-describe '#sadd(key, member)' do
+RSpec.describe '#sadd(key, member)' do
   before { @key = 'mock-redis-test:sadd' }
 
   it 'returns true if the set did not already contain member' do
-    @redises.sadd(@key, 1).should == true
+    expect(@redises.sadd(@key, 1)).to eq(true)
   end
 
   it 'returns false if the set did already contain member' do
     @redises.sadd(@key, 1)
-    @redises.sadd(@key, 1).should == false
+    expect(@redises.sadd(@key, 1)).to eq(false)
   end
 
   it 'adds member to the set' do
     @redises.sadd(@key, 1)
     @redises.sadd(@key, 2)
-    @redises.smembers(@key).should == %w[2 1]
+    expect(@redises.smembers(@key)).to eq(%w[2 1])
   end
 
   describe 'adding multiple members at once' do
     it 'returns the amount of added members' do
-      @redises.sadd(@key, [1, 2, 3]).should == 3
-      @redises.sadd(@key, [1, 2, 3, 4]).should == 1
+      expect(@redises.sadd(@key, [1, 2, 3])).to eq(3)
+      expect(@redises.sadd(@key, [1, 2, 3, 4])).to eq(1)
     end
 
     it 'returns 0 if the set did already contain all members' do
       @redises.sadd(@key, [1, 2, 3])
-      @redises.sadd(@key, [1, 2, 3]).should == 0
+      expect(@redises.sadd(@key, [1, 2, 3])).to eq(0)
     end
 
     it 'adds the members to the set' do
       @redises.sadd(@key, [1, 2, 3])
-      @redises.smembers(@key).should == %w[1 2 3]
+      expect(@redises.smembers(@key)).to eq(%w[1 2 3])
     end
 
     it 'raises an error if an empty array is given' do
-      lambda do
+      expect do
         @redises.sadd(@key, [])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 

--- a/spec/commands/save_spec.rb
+++ b/spec/commands/save_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#save' do
+RSpec.describe '#save' do
   it "responds with 'OK'" do
-    @redises.save.should == 'OK'
+    expect(@redises.save).to eq('OK')
   end
 end

--- a/spec/commands/scan_each_spec.rb
+++ b/spec/commands/scan_each_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#scan_each' do
+RSpec.describe '#scan_each' do
   subject { MockRedis::Database.new(self) }
 
   let(:match) { '*' }

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#scan' do
+RSpec.describe '#scan' do
   subject { MockRedis::Database.new(self) }
 
   let(:count) { 10 }

--- a/spec/commands/scard_spec.rb
+++ b/spec/commands/scard_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe '#scard(key)' do
+RSpec.describe '#scard(key)' do
   before { @key = 'mock-redis-test:scard' }
 
   it 'returns 0 for an empty set' do
-    @redises.scard(@key).should == 0
+    expect(@redises.scard(@key)).to eq(0)
   end
 
   it 'returns the number of elements in the set' do
     @redises.sadd(@key, 'one')
     @redises.sadd(@key, 'two')
     @redises.sadd(@key, 'three')
-    @redises.scard(@key).should == 3
+    expect(@redises.scard(@key)).to eq(3)
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/script_spec.rb
+++ b/spec/commands/script_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#script(subcommand, *args)' do
+RSpec.describe '#script(subcommand, *args)' do
   before { @key = 'mock-redis-test:script' }
 
   it 'works with load subcommand' do

--- a/spec/commands/sdiff_spec.rb
+++ b/spec/commands/sdiff_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sdiff(key [, key, ...])' do
+RSpec.describe '#sdiff(key [, key, ...])' do
   before do
     @numbers = 'mock-redis-test:sdiff:numbers'
     @evens   = 'mock-redis-test:sdiff:odds'
@@ -12,36 +12,36 @@ describe '#sdiff(key [, key, ...])' do
   end
 
   it 'returns the first set minus the second set' do
-    @redises.sdiff(@numbers, @evens).should == %w[1 3 5 7 9]
+    expect(@redises.sdiff(@numbers, @evens)).to eq(%w[1 3 5 7 9])
   end
 
   it 'returns the first set minus all the other sets' do
-    @redises.sdiff(@numbers, @evens, @primes).should == %w[1 9]
+    expect(@redises.sdiff(@numbers, @evens, @primes)).to eq(%w[1 9])
   end
 
   it 'treats missing keys as empty sets' do
-    @redises.sdiff(@evens, 'mock-redis-test:nonesuch').should == %w[2 4 6 8 10]
+    expect(@redises.sdiff(@evens, 'mock-redis-test:nonesuch')).to eq(%w[2 4 6 8 10])
   end
 
   it 'returns the first set when called with a single argument' do
-    @redises.sdiff(@primes).should == %w[2 3 5 7]
+    expect(@redises.sdiff(@primes)).to eq(%w[2 3 5 7])
   end
 
   it 'raises an error if given 0 arguments' do
-    lambda do
+    expect do
       @redises.sdiff
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('foo', 1)
 
-    lambda do
+    expect do
       @redises.sdiff(@numbers, 'foo')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sdiff('foo', @numbers)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/sdiffstore_spec.rb
+++ b/spec/commands/sdiffstore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sdiffstore(destination, key [, key, ...])' do
+RSpec.describe '#sdiffstore(destination, key [, key, ...])' do
   before do
     @numbers     = 'mock-redis-test:sdiffstore:numbers'
     @evens       = 'mock-redis-test:sdiffstore:evens'
@@ -13,46 +13,46 @@ describe '#sdiffstore(destination, key [, key, ...])' do
   end
 
   it 'returns the number of elements in the resulting set' do
-    @redises.sdiffstore(@destination, @numbers, @evens).should == 5
+    expect(@redises.sdiffstore(@destination, @numbers, @evens)).to eq(5)
   end
 
   it 'stores the resulting set' do
     @redises.sdiffstore(@destination, @numbers, @evens)
-    @redises.smembers(@destination).should == %w[9 7 5 3 1]
+    expect(@redises.smembers(@destination)).to eq(%w[9 7 5 3 1])
   end
 
   it 'does not store empty sets' do
-    @redises.sdiffstore(@destination, @numbers, @numbers).should == 0
-    @redises.get(@destination).should be_nil
+    expect(@redises.sdiffstore(@destination, @numbers, @numbers)).to eq(0)
+    expect(@redises.get(@destination)).to be_nil
   end
 
   it 'treats missing keys as empty sets' do
     @redises.sdiffstore(@destination, @evens, 'mock-redis-test:nonesuch')
-    @redises.smembers(@destination).should == %w[10 8 6 4 2]
+    expect(@redises.smembers(@destination)).to eq(%w[10 8 6 4 2])
   end
 
   it 'removes existing elements in destination' do
     @redises.sadd(@destination, 42)
 
     @redises.sdiffstore(@destination, @primes)
-    @redises.smembers(@destination).should == %w[7 5 3 2]
+    expect(@redises.smembers(@destination)).to eq(%w[7 5 3 2])
   end
 
   it 'raises an error if given 0 sets' do
-    lambda do
+    expect do
       @redises.sdiffstore(@destination)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('mock-redis-test:notset', 1)
 
-    lambda do
+    expect do
       @redises.sdiffstore(@destination, @numbers, 'mock-redis-test:notset')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sdiffstore(@destination, 'mock-redis-test:notset', @numbers)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/select_spec.rb
+++ b/spec/commands/select_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe '#select(db)' do
+RSpec.describe '#select(db)' do
   before { @key = 'mock-redis-test:select' }
 
   it "returns 'OK'" do
-    @redises.select(0).should == 'OK'
+    expect(@redises.select(0)).to eq('OK')
   end
 
   it "treats '0' and 0 the same" do
     @redises.select('0')
     @redises.set(@key, 'foo')
     @redises.select(0)
-    @redises.get(@key).should == 'foo'
+    expect(@redises.get(@key)).to eq('foo')
   end
 
   it 'switches databases' do
@@ -19,17 +19,17 @@ describe '#select(db)' do
     @redises.set(@key, 'foo')
 
     @redises.select(1)
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
 
     @redises.select(0)
-    @redises.get(@key).should == 'foo'
+    expect(@redises.get(@key)).to eq('foo')
   end
 
   context '[mock only]' do
     # Time dependence introduces a bit of nondeterminism here
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
 
       @mock = @redises.mock
 
@@ -44,18 +44,18 @@ describe '#select(db)' do
 
     it 'keeps expire times per-db' do
       @mock.select(0)
-      @mock.ttl(@key).should == 100
+      expect(@mock.ttl(@key)).to eq(100)
 
       @mock.select(1)
-      @mock.ttl(@key).should == 200
+      expect(@mock.ttl(@key)).to eq(200)
     end
 
     it 'keeps expire times in miliseconds per-db' do
       @mock.select(0)
-      (100_000 - 1000..100_000 + 1000).should cover(@mock.pttl(@key))
+      expect(100_000 - 1000..100_000 + 1000).to cover(@mock.pttl(@key))
 
       @mock.select(1)
-      (200_000 - 1000..200_000 + 1000).should cover(@mock.pttl(@key))
+      expect(200_000 - 1000..200_000 + 1000).to cover(@mock.pttl(@key))
     end
   end
 end

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe '#set(key, value)' do
+RSpec.describe '#set(key, value)' do
   let(:key) { 'mock-redis-test' }
 
   it "responds with 'OK'" do
-    @redises.set('mock-redis-test', 1).should == 'OK'
+    expect(@redises.set('mock-redis-test', 1)).to eq('OK')
   end
 
   context 'options' do
@@ -22,26 +22,26 @@ describe '#set(key, value)' do
 
     it 'accepts NX' do
       @redises.del(key)
-      @redises.set(key, 1, nx: true).should == true
-      @redises.set(key, 1, nx: true).should == false
+      expect(@redises.set(key, 1, nx: true)).to eq(true)
+      expect(@redises.set(key, 1, nx: true)).to eq(false)
     end
 
     it 'accepts XX' do
       @redises.del(key)
-      @redises.set(key, 1, xx: true).should == false
-      @redises.set(key, 1).should == 'OK'
-      @redises.set(key, 1, xx: true).should == true
+      expect(@redises.set(key, 1, xx: true)).to eq(false)
+      expect(@redises.set(key, 1)).to eq('OK')
+      expect(@redises.set(key, 1, xx: true)).to eq(true)
     end
 
     it 'accepts GET on a string' do
-      @redises.set(key, '1').should == 'OK'
-      @redises.set(key, '2', get: true).should == '1'
-      @redises.set(key, '3', get: true).should == '2'
+      expect(@redises.set(key, '1')).to eq('OK')
+      expect(@redises.set(key, '2', get: true)).to eq('1')
+      expect(@redises.set(key, '3', get: true)).to eq('2')
     end
 
     context 'when set key is not a String' do
       it 'should error with Redis::CommandError' do
-        @redises.lpush(key, '1').should == 1
+        expect(@redises.lpush(key, '1')).to eq(1)
         expect do
           @redises.set(key, '2', get: true)
         end.to raise_error(Redis::CommandError)
@@ -111,23 +111,23 @@ describe '#set(key, value)' do
 
       before do
         @now = Time.now
-        Time.stub(:now).and_return(@now)
+        allow(Time).to receive(:now).and_return(@now)
       end
 
       it 'accepts EX seconds' do
-        @mock.set(key, 1, ex: 1).should == 'OK'
-        @mock.get(key).should_not be_nil
-        Time.stub(:now).and_return(@now + 2)
-        @mock.get(key).should be_nil
+        expect(@mock.set(key, 1, ex: 1)).to eq('OK')
+        expect(@mock.get(key)).not_to be_nil
+        allow(Time).to receive(:now).and_return(@now + 2)
+        expect(@mock.get(key)).to be_nil
       end
 
       it 'accepts PX milliseconds' do
-        @mock.set(key, 1, px: 500).should == 'OK'
-        @mock.get(key).should_not be_nil
-        Time.stub(:now).and_return(@now + 300 / 1000.to_f)
-        @mock.get(key).should_not be_nil
-        Time.stub(:now).and_return(@now + 600 / 1000.to_f)
-        @mock.get(key).should be_nil
+        expect(@mock.set(key, 1, px: 500)).to eq('OK')
+        expect(@mock.get(key)).not_to be_nil
+        allow(Time).to receive(:now).and_return(@now + 300 / 1000.to_f)
+        expect(@mock.get(key)).not_to be_nil
+        allow(Time).to receive(:now).and_return(@now + 600 / 1000.to_f)
+        expect(@mock.get(key)).to be_nil
       end
     end
   end

--- a/spec/commands/setbit_spec.rb
+++ b/spec/commands/setbit_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#setbit(key, offset)' do
+RSpec.describe '#setbit(key, offset)' do
   before do
     Encoding.default_external = 'UTF-8'
     @key = 'mock-redis-test:setbit'
@@ -8,47 +8,47 @@ describe '#setbit(key, offset)' do
   end
 
   it "returns the original stored bit's value" do
-    @redises.setbit(@key, 0, 1).should == 0
-    @redises.setbit(@key, 1, 1).should == 1
+    expect(@redises.setbit(@key, 0, 1)).to eq(0)
+    expect(@redises.setbit(@key, 1, 1)).to eq(1)
   end
 
   it 'sets the bit within the string' do
     @redises.setbit(@key, 7, 1)
-    @redises.get(@key).should == 'i'  # ASCII 0x69
+    expect(@redises.get(@key)).to eq('i')  # ASCII 0x69
   end
 
   it 'unsets the bit within the string' do
     @redises.setbit(@key, 1, 0)
-    @redises.get(@key).should == '('  # ASCII 0x28
+    expect(@redises.get(@key)).to eq('(')  # ASCII 0x28
   end
 
   it 'does the right thing with multibyte characters' do
     @redises.set(@key, '€99.94') # the euro sign is 3 bytes wide in UTF-8
-    @redises.setbit(@key, 63, 1).should == 0
-    @redises.get(@key).should == '€99.95'
+    expect(@redises.setbit(@key, 63, 1)).to eq(0)
+    expect(@redises.get(@key)).to eq('€99.95')
   end
 
   it 'expands the string if necessary' do
     @redises.setbit(@key, 9, 1)
-    @redises.get(@key).should == 'h@'
+    expect(@redises.get(@key)).to eq('h@')
   end
 
   it 'sets added bits to 0' do
     @redises.setbit(@key, 17, 1)
-    @redises.get(@key).should == "h\000@"
+    expect(@redises.get(@key)).to eq("h\000@")
   end
 
   it 'treats missing keys as empty strings' do
     @redises.del(@key)
     @redises.setbit(@key, 1, 1)
-    @redises.get(@key).should == '@'
+    expect(@redises.get(@key)).to eq('@')
   end
 
   it 'sets and retrieves bits' do
     @redises.setbit(@key, 22, 1)
-    @redises.getbit(@key, 22).should == 1
+    expect(@redises.getbit(@key, 22)).to eq(1)
     @redises.setbit(@key, 23, 0)
-    @redises.getbit(@key, 23).should == 0
+    expect(@redises.getbit(@key, 23)).to eq(0)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/setex_spec.rb
+++ b/spec/commands/setex_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe '#setex(key, seconds, value)' do
+RSpec.describe '#setex(key, seconds, value)' do
   before { @key = 'mock-redis-test:setex' }
 
   it "responds with 'OK'" do
-    @redises.setex(@key, 10, 'value').should == 'OK'
+    expect(@redises.setex(@key, 10, 'value')).to eq('OK')
   end
 
   it 'sets the value' do
     @redises.setex(@key, 10_000, 'value')
-    @redises.get(@key).should == 'value'
+    expect(@redises.get(@key)).to eq('value')
   end
 
   it 'sets the expiration time' do
     @redises.setex(@key, 10_000, 'value')
 
     # no guarantee these are the same
-    @redises.real.ttl(@key).should > 0
-    @redises.mock.ttl(@key).should > 0
+    expect(@redises.real.ttl(@key)).to be > 0
+    expect(@redises.mock.ttl(@key)).to be > 0
   end
 
   context 'when expiration time is zero' do

--- a/spec/commands/setnx_spec.rb
+++ b/spec/commands/setnx_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
-describe '#setnx(key, value)' do
+RSpec.describe '#setnx(key, value)' do
   before { @key = 'mock-redis-test:setnx' }
 
   it 'returns true if the key was absent' do
-    @redises.setnx(@key, 1).should == true
+    expect(@redises.setnx(@key, 1)).to eq(true)
   end
 
   it 'returns false if the key was present' do
     @redises.set(@key, 2)
-    @redises.setnx(@key, 1).should == false
+    expect(@redises.setnx(@key, 1)).to eq(false)
   end
 
   it 'sets the value if missing' do
     @redises.setnx(@key, 'value')
-    @redises.get(@key).should == 'value'
+    expect(@redises.get(@key)).to eq('value')
   end
 
   it 'does nothing if the value is present' do
     @redises.set(@key, 'old')
     @redises.setnx(@key, 'new')
-    @redises.get(@key).should == 'old'
+    expect(@redises.get(@key)).to eq('old')
   end
 end

--- a/spec/commands/setrange_spec.rb
+++ b/spec/commands/setrange_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-describe '#setrange(key, offset, value)' do
+RSpec.describe '#setrange(key, offset, value)' do
   before do
     @key = 'mock-redis-test:setrange'
     @redises.set(@key, 'This is a string')
   end
 
   it "returns the string's new length" do
-    @redises.setrange(@key, 0, 'That').should == 16
+    expect(@redises.setrange(@key, 0, 'That')).to eq(16)
   end
 
   it 'updates part of the string' do
     @redises.setrange(@key, 0, 'That')
-    @redises.get(@key).should == 'That is a string'
+    expect(@redises.get(@key)).to eq('That is a string')
   end
 
   it 'zero-pads the string if necessary' do
     @redises.setrange(@key, 20, 'X')
-    @redises.get(@key).should == "This is a string\000\000\000\000X"
+    expect(@redises.get(@key)).to eq("This is a string\000\000\000\000X")
   end
 
   it 'stores things as strings' do
     other_key = 'mock-redis-test:setrange-other-key'
     @redises.setrange(other_key, 0, 1)
-    @redises.get(other_key).should == '1'
+    expect(@redises.get(other_key)).to eq('1')
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/sinter_spec.rb
+++ b/spec/commands/sinter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sinter(key [, key, ...])' do
+RSpec.describe '#sinter(key [, key, ...])' do
   before do
     @numbers = 'mock-redis-test:sinter:numbers'
     @evens   = 'mock-redis-test:sinter:evens'
@@ -12,28 +12,28 @@ describe '#sinter(key [, key, ...])' do
   end
 
   it 'returns the elements in the resulting set' do
-    @redises.sinter(@evens, @primes).should == ['2']
+    expect(@redises.sinter(@evens, @primes)).to eq(['2'])
   end
 
   it 'treats missing keys as empty sets' do
-    @redises.sinter(@destination, 'mock-redis-test:nonesuch').should == []
+    expect(@redises.sinter(@destination, 'mock-redis-test:nonesuch')).to eq([])
   end
 
   it 'raises an error if given 0 sets' do
-    lambda do
+    expect do
       @redises.sinter
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('mock-redis-test:notset', 1)
 
-    lambda do
+    expect do
       @redises.sinter(@numbers, 'mock-redis-test:notset')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sinter('mock-redis-test:notset', @numbers)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/sinterstore_spec.rb
+++ b/spec/commands/sinterstore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sinterstore(destination, key [, key, ...])' do
+RSpec.describe '#sinterstore(destination, key [, key, ...])' do
   before do
     @numbers     = 'mock-redis-test:sinterstore:numbers'
     @evens       = 'mock-redis-test:sinterstore:evens'
@@ -13,41 +13,41 @@ describe '#sinterstore(destination, key [, key, ...])' do
   end
 
   it 'returns the number of elements in the resulting set' do
-    @redises.sinterstore(@destination, @numbers, @evens).should == 5
+    expect(@redises.sinterstore(@destination, @numbers, @evens)).to eq(5)
   end
 
   it 'stores the resulting set' do
     @redises.sinterstore(@destination, @numbers, @evens)
-    @redises.smembers(@destination).should == %w[10 8 6 4 2]
+    expect(@redises.smembers(@destination)).to eq(%w[10 8 6 4 2])
   end
 
   it 'does not store empty sets' do
-    @redises.sinterstore(@destination, 'mock-redis-test:nonesuch', @numbers).should == 0
-    @redises.get(@destination).should be_nil
+    expect(@redises.sinterstore(@destination, 'mock-redis-test:nonesuch', @numbers)).to eq(0)
+    expect(@redises.get(@destination)).to be_nil
   end
 
   it 'removes existing elements in destination' do
     @redises.sadd(@destination, 42)
 
     @redises.sinterstore(@destination, @primes)
-    @redises.smembers(@destination).should == %w[7 5 3 2]
+    expect(@redises.smembers(@destination)).to eq(%w[7 5 3 2])
   end
 
   it 'raises an error if given 0 sets' do
-    lambda do
+    expect do
       @redises.sinterstore(@destination)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('mock-redis-test:notset', 1)
 
-    lambda do
+    expect do
       @redises.sinterstore(@destination, @numbers, 'mock-redis-test:notset')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sinterstore(@destination, 'mock-redis-test:notset', @numbers)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/sismember_spec.rb
+++ b/spec/commands/sismember_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sismember(key, member)' do
+RSpec.describe '#sismember(key, member)' do
   before do
     @key = 'mock-redis-test:sismember'
     @redises.sadd(@key, 'whiskey')
@@ -8,21 +8,21 @@ describe '#sismember(key, member)' do
   end
 
   it 'returns true if member is in set' do
-    @redises.sismember(@key, 'whiskey').should == true
-    @redises.sismember(@key, 'beer').should == true
+    expect(@redises.sismember(@key, 'whiskey')).to eq(true)
+    expect(@redises.sismember(@key, 'beer')).to eq(true)
   end
 
   it 'returns false if member is not in set' do
-    @redises.sismember(@key, 'cola').should == false
+    expect(@redises.sismember(@key, 'cola')).to eq(false)
   end
 
   it 'stringifies member' do
     @redises.sadd(@key, '1')
-    @redises.sismember(@key, 1).should == true
+    expect(@redises.sismember(@key, 1)).to eq(true)
   end
 
   it 'treats a nonexistent value as an empty set' do
-    @redises.sismember('mock-redis-test:nonesuch', 'beer').should == false
+    expect(@redises.sismember('mock-redis-test:nonesuch', 'beer')).to eq(false)
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/smembers_spec.rb
+++ b/spec/commands/smembers_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe '#smembers(key)' do
+RSpec.describe '#smembers(key)' do
   before { @key = 'mock-redis-test:smembers' }
 
   it 'returns [] for an empty set' do
-    @redises.smembers(@key).should == []
+    expect(@redises.smembers(@key)).to eq([])
   end
 
   it "returns the set's members" do
     @redises.sadd(@key, 'Hello')
     @redises.sadd(@key, 'World')
     @redises.sadd(@key, 'Test')
-    @redises.smembers(@key).should == %w[Test World Hello]
+    expect(@redises.smembers(@key)).to eq(%w[Test World Hello])
   end
 
   it 'returns unfrozen copies of the input' do

--- a/spec/commands/smismember_spec.rb
+++ b/spec/commands/smismember_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#smismember(key, *members)' do
+RSpec.describe '#smismember(key, *members)' do
   before do
     @key = 'mock-redis-test:smismember'
     @redises.sadd(@key, 'whiskey')
@@ -8,26 +8,26 @@ describe '#smismember(key, *members)' do
   end
 
   it 'returns true if member is in set' do
-    @redises.smismember(@key, 'whiskey').should == [true]
-    @redises.smismember(@key, 'beer').should == [true]
-    @redises.smismember(@key, 'whiskey', 'beer').should == [true, true]
-    @redises.smismember(@key, %w[whiskey beer]).should == [true, true]
+    expect(@redises.smismember(@key, 'whiskey')).to eq([true])
+    expect(@redises.smismember(@key, 'beer')).to eq([true])
+    expect(@redises.smismember(@key, 'whiskey', 'beer')).to eq([true, true])
+    expect(@redises.smismember(@key, %w[whiskey beer])).to eq([true, true])
   end
 
   it 'returns false if member is not in set' do
-    @redises.smismember(@key, 'cola').should == [false]
-    @redises.smismember(@key, 'whiskey', 'cola').should == [true, false]
-    @redises.smismember(@key, %w[whiskey beer cola]).should == [true, true, false]
+    expect(@redises.smismember(@key, 'cola')).to eq([false])
+    expect(@redises.smismember(@key, 'whiskey', 'cola')).to eq([true, false])
+    expect(@redises.smismember(@key, %w[whiskey beer cola])).to eq([true, true, false])
   end
 
   it 'stringifies member' do
     @redises.sadd(@key, '1')
-    @redises.smismember(@key, 1).should == [true]
-    @redises.smismember(@key, [1]).should == [true]
+    expect(@redises.smismember(@key, 1)).to eq([true])
+    expect(@redises.smismember(@key, [1])).to eq([true])
   end
 
   it 'treats a nonexistent value as an empty set' do
-    @redises.smismember('mock-redis-test:nonesuch', 'beer').should == [false]
+    expect(@redises.smismember('mock-redis-test:nonesuch', 'beer')).to eq([false])
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/smove_spec.rb
+++ b/spec/commands/smove_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#smove(source, destination, member)' do
+RSpec.describe '#smove(source, destination, member)' do
   before do
     @src  = 'mock-redis-test:smove-source'
     @dest = 'mock-redis-test:smove-destination'
@@ -10,31 +10,31 @@ describe '#smove(source, destination, member)' do
   end
 
   it 'returns true if the member exists in src' do
-    @redises.smove(@src, @dest, 1).should == true
+    expect(@redises.smove(@src, @dest, 1)).to eq(true)
   end
 
   it 'returns false if the member exists in src' do
-    @redises.smove(@src, @dest, 'nope').should == false
+    expect(@redises.smove(@src, @dest, 'nope')).to eq(false)
   end
 
   it 'returns true if the member exists in src and dest' do
     @redises.sadd(@dest, 1)
-    @redises.smove(@src, @dest, 1).should == true
+    expect(@redises.smove(@src, @dest, 1)).to eq(true)
   end
 
   it 'moves member from source to destination' do
     @redises.smove(@src, @dest, 1)
-    @redises.sismember(@dest, 1).should == true
-    @redises.sismember(@src, 1).should == false
+    expect(@redises.sismember(@dest, 1)).to eq(true)
+    expect(@redises.sismember(@src, 1)).to eq(false)
   end
 
   it 'cleans up empty sets' do
     @redises.smove(@src, @dest, 1)
-    @redises.get(@src).should be_nil
+    expect(@redises.get(@src)).to be_nil
   end
 
   it 'treats a nonexistent value as an empty set' do
-    @redises.smove('mock-redis-test:nonesuch', @dest, 1).should == false
+    expect(@redises.smove('mock-redis-test:nonesuch', @dest, 1)).to eq(false)
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/sort_list_spec.rb
+++ b/spec/commands/sort_list_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sort(key, options)' do
+RSpec.describe '#sort(key, options)' do
   before do
     @key = 'mock-redis-test:list_sort'
 

--- a/spec/commands/sort_set_spec.rb
+++ b/spec/commands/sort_set_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sort(key, options)' do
+RSpec.describe '#sort(key, options)' do
   before do
     @key = 'mock-redis-test:set_sort'
 

--- a/spec/commands/sort_zset_spec.rb
+++ b/spec/commands/sort_zset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sort(key, options)' do
+RSpec.describe '#sort(key, options)' do
   before do
     @key = 'mock-redis-test:zset_sort'
 

--- a/spec/commands/spop_spec.rb
+++ b/spec/commands/spop_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#spop(key)' do
+RSpec.describe '#spop(key)' do
   before do
     @key = 'mock-redis-test:spop'
 
@@ -8,32 +8,32 @@ describe '#spop(key)' do
   end
 
   it 'returns a member of the set' do
-    @redises.spop(@key).should == 'value'
+    expect(@redises.spop(@key)).to eq('value')
   end
 
   it 'removes a member of the set' do
     @redises.spop(@key)
-    @redises.smembers(@key).should == []
+    expect(@redises.smembers(@key)).to eq([])
   end
 
   it 'returns nil if the set is empty' do
     @redises.spop(@key)
-    @redises.spop(@key).should be_nil
+    expect(@redises.spop(@key)).to be_nil
   end
 
   it 'returns an array if count is not nil' do
     @redises.sadd(@key, 'value2')
-    @redises.spop(@key, 2).should == %w[value value2]
+    expect(@redises.spop(@key, 2)).to eq(%w[value value2])
   end
 
   it 'returns only whats in the set' do
-    @redises.spop(@key, 2).should == ['value']
-    @redises.smembers(@key).should == []
+    expect(@redises.spop(@key, 2)).to eq(['value'])
+    expect(@redises.smembers(@key)).to eq([])
   end
 
   it 'returns an empty array if count is not nil and the set it empty' do
     @redises.spop(@key)
-    @redises.spop(@key, 100).should == []
+    expect(@redises.spop(@key, 100)).to eq([])
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/srandmember_spec.rb
+++ b/spec/commands/srandmember_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe '#srandmember(key)' do
     # NOTE: We disable result checking since MockRedis and Redis will likely
     # return a different random set (since the selection is, well, random)
     it 'returns the whole set if count is greater than the set size' do
-      expect(@redises.send_without_checking(:srandmember, @key, 5)).to match_array(%w[value value2 value3])
+      expect(@redises.send_without_checking(:srandmember, @key, 5))
+        .to match_array(%w[value value2 value3])
     end
 
     it 'returns random members up to count from the set when count is smaller than the set size' do

--- a/spec/commands/srandmember_spec.rb
+++ b/spec/commands/srandmember_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#srandmember(key)' do
+RSpec.describe '#srandmember(key)' do
   before do
     @key = 'mock-redis-test:srandmember'
 
@@ -8,17 +8,17 @@ describe '#srandmember(key)' do
   end
 
   it 'returns a member of the set' do
-    @redises.srandmember(@key).should == 'value'
+    expect(@redises.srandmember(@key)).to eq('value')
   end
 
   it 'does not modify the set' do
     @redises.srandmember(@key)
-    @redises.smembers(@key).should == ['value']
+    expect(@redises.smembers(@key)).to eq(['value'])
   end
 
   it 'returns nil if the set is empty' do
     @redises.spop(@key)
-    @redises.srandmember(@key).should be_nil
+    expect(@redises.srandmember(@key)).to be_nil
   end
 
   context 'when count argument is specified' do
@@ -30,20 +30,20 @@ describe '#srandmember(key)' do
     # NOTE: We disable result checking since MockRedis and Redis will likely
     # return a different random set (since the selection is, well, random)
     it 'returns the whole set if count is greater than the set size' do
-      @redises.send_without_checking(:srandmember, @key, 5).should =~ %w[value value2 value3]
+      expect(@redises.send_without_checking(:srandmember, @key, 5)).to match_array(%w[value value2 value3])
     end
 
     it 'returns random members up to count from the set when count is smaller than the set size' do
-      @redises.send_without_checking(:srandmember, @key, 2).size.should == 2
+      expect(@redises.send_without_checking(:srandmember, @key, 2).size).to eq(2)
     end
 
     it 'returns random members up to count from the set when count is negative even if count.abs is greater than the set size' do # rubocop:disable Layout/LineLength
-      @redises.send_without_checking(:srandmember, @key, -5).size.should == 5
+      expect(@redises.send_without_checking(:srandmember, @key, -5).size).to eq(5)
     end
 
     it 'returns nil if the set is empty' do
       @redises.srem(@key, %w[value value2 value3])
-      @redises.srandmember(@key, 2).should be_empty
+      expect(@redises.srandmember(@key, 2)).to be_empty
     end
   end
 end

--- a/spec/commands/srem_spec.rb
+++ b/spec/commands/srem_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#srem(key, member)' do
+RSpec.describe '#srem(key, member)' do
   before do
     @key = 'mock-redis-test:srem'
 
@@ -9,36 +9,36 @@ describe '#srem(key, member)' do
   end
 
   it 'returns true if member is in the set' do
-    @redises.srem(@key, 'bert').should == true
+    expect(@redises.srem(@key, 'bert')).to eq(true)
   end
 
   it 'returns false if member is not in the set' do
-    @redises.srem(@key, 'cookiemonster').should == false
+    expect(@redises.srem(@key, 'cookiemonster')).to eq(false)
   end
 
   it 'removes member from the set' do
     @redises.srem(@key, 'ernie')
-    @redises.smembers(@key).should == ['bert']
+    expect(@redises.smembers(@key)).to eq(['bert'])
   end
 
   it 'stringifies member' do
     @redises.sadd(@key, '1')
-    @redises.srem(@key, 1).should == true
+    expect(@redises.srem(@key, 1)).to eq(true)
   end
 
   it 'cleans up empty sets' do
     @redises.smembers(@key).each { |m| @redises.srem(@key, m) }
-    @redises.get(@key).should be_nil
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'supports a variable number of arguments' do
-    @redises.srem(@key, %w[bert ernie]).should == 2
-    @redises.get(@key).should be_nil
+    expect(@redises.srem(@key, %w[bert ernie])).to eq(2)
+    expect(@redises.get(@key)).to be_nil
   end
 
   it 'allow passing an array of integers as argument' do
     @redises.sadd(@key, %w[1 2])
-    @redises.srem(@key, [1, 2]).should == 2
+    expect(@redises.srem(@key, [1, 2])).to eq(2)
   end
 
   it_should_behave_like 'a set-only command'

--- a/spec/commands/sscan_each_spec.rb
+++ b/spec/commands/sscan_each_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sscan_each' do
+RSpec.describe '#sscan_each' do
   subject { MockRedis::Database.new(self) }
 
   let(:key) { 'mock-redis-test:sscan_each' }

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sscan' do
+RSpec.describe '#sscan' do
   let(:count) { 10 }
   let(:match) { '*' }
   let(:key) { 'mock-redis-test:sscan' }

--- a/spec/commands/strlen_spec.rb
+++ b/spec/commands/strlen_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe '#strlen(key)' do
+RSpec.describe '#strlen(key)' do
   before do
     @key = 'mock-redis-test:73288'
     @redises.set(@key, '5 ∈ (0..10)')
   end
 
   it "returns the string's length in bytes" do
-    @redises.strlen(@key).should == 13
+    expect(@redises.strlen(@key)).to eq(13)
   end
 
   it 'returns 0 for a nonexistent value' do
-    @redises.strlen('mock-redis-test:does-not-exist').should == 0
+    expect(@redises.strlen('mock-redis-test:does-not-exist')).to eq(0)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/sunion_spec.rb
+++ b/spec/commands/sunion_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sunion(key [, key, ...])' do
+RSpec.describe '#sunion(key [, key, ...])' do
   before do
     @evens   = 'mock-redis-test:sunion:evens'
     @primes  = 'mock-redis-test:sunion:primes'
@@ -10,33 +10,33 @@ describe '#sunion(key [, key, ...])' do
   end
 
   it 'returns the elements in the resulting set' do
-    @redises.sunion(@evens, @primes).should == %w[2 4 6 8 10 3 5 7]
+    expect(@redises.sunion(@evens, @primes)).to eq(%w[2 4 6 8 10 3 5 7])
   end
 
   it 'treats missing keys as empty sets' do
-    @redises.sunion(@primes, 'mock-redis-test:nonesuch').
-      should == %w[2 3 5 7]
+    expect(@redises.sunion(@primes, 'mock-redis-test:nonesuch')).
+      to eq(%w[2 3 5 7])
   end
 
   it 'allows Array as argument' do
-    @redises.sunion([@evens, @primes]).should == %w[2 4 6 8 10 3 5 7]
+    expect(@redises.sunion([@evens, @primes])).to eq(%w[2 4 6 8 10 3 5 7])
   end
 
   it 'raises an error if given 0 sets' do
-    lambda do
+    expect do
       @redises.sunion
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('mock-redis-test:notset', 1)
 
-    lambda do
+    expect do
       @redises.sunion(@numbers, 'mock-redis-test:notset')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sunion('mock-redis-test:notset', @numbers)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/sunionstore_spec.rb
+++ b/spec/commands/sunionstore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#sunionstore(destination, key [, key, ...])' do
+RSpec.describe '#sunionstore(destination, key [, key, ...])' do
   before do
     @evens       = 'mock-redis-test:sunionstore:evens'
     @primes      = 'mock-redis-test:sunionstore:primes'
@@ -11,49 +11,49 @@ describe '#sunionstore(destination, key [, key, ...])' do
   end
 
   it 'returns the number of elements in the resulting set' do
-    @redises.sunionstore(@destination, @primes, @evens).should == 8
+    expect(@redises.sunionstore(@destination, @primes, @evens)).to eq(8)
   end
 
   it 'stores the resulting set' do
     @redises.sunionstore(@destination, @primes, @evens)
-    @redises.smembers(@destination).should == %w[10 8 6 4 7 5 3 2]
+    expect(@redises.smembers(@destination)).to eq(%w[10 8 6 4 7 5 3 2])
   end
 
   it 'does not store empty sets' do
-    @redises.sunionstore(@destination,
+    expect(@redises.sunionstore(@destination,
       'mock-redis-test:nonesuch',
-      'mock-redis-test:nonesuch2').should == 0
-    @redises.get(@destination).should be_nil
+      'mock-redis-test:nonesuch2')).to eq(0)
+    expect(@redises.get(@destination)).to be_nil
   end
 
   it 'removes existing elements in destination' do
     @redises.sadd(@destination, 42)
 
     @redises.sunionstore(@destination, @primes)
-    @redises.smembers(@destination).should == %w[7 5 3 2]
+    expect(@redises.smembers(@destination)).to eq(%w[7 5 3 2])
   end
 
   it 'correctly unions and stores when the destination is empty and is one of the arguments' do
     @redises.sunionstore(@destination, @destination, @primes)
 
-    @redises.smembers(@destination).should == %w[7 5 3 2]
+    expect(@redises.smembers(@destination)).to eq(%w[7 5 3 2])
   end
 
   it 'raises an error if given 0 sets' do
-    lambda do
+    expect do
       @redises.sunionstore(@destination)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'raises an error if any argument is not a a set' do
     @redises.set('mock-redis-test:notset', 1)
 
-    lambda do
+    expect do
       @redises.sunionstore(@destination, @primes, 'mock-redis-test:notset')
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.sunionstore(@destination, 'mock-redis-test:notset', @primes)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/commands/ttl_spec.rb
+++ b/spec/commands/ttl_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 
-describe '#ttl(key)' do
+RSpec.describe '#ttl(key)' do
   before do
     @key = 'mock-redis-test:persist'
     @redises.set(@key, 'spork')
   end
 
   it 'returns -1 for a key with no expiration' do
-    @redises.ttl(@key).should == -1
+    expect(@redises.ttl(@key)).to eq(-1)
   end
 
   it 'returns -2 for a key that does not exist' do
-    @redises.ttl('mock-redis-test:nonesuch').should == -2
+    expect(@redises.ttl('mock-redis-test:nonesuch')).to eq(-2)
   end
 
   it 'stringifies key' do
     @redises.expire(@key, 9)
-    @redises.ttl(@key.to_sym).should > 0
+    expect(@redises.ttl(@key.to_sym)).to be > 0
   end
 
   context '[mock only]' do
@@ -29,12 +29,12 @@ describe '#ttl(key)' do
 
     before do
       @now = Time.now
-      Time.stub(:now).and_return(@now)
+      allow(Time).to receive(:now).and_return(@now)
     end
 
     it "gives you the key's remaining lifespan in seconds" do
       @mock.expire(@key, 5)
-      @mock.ttl(@key).should == 5
+      expect(@mock.ttl(@key)).to eq(5)
     end
   end
 end

--- a/spec/commands/type_spec.rb
+++ b/spec/commands/type_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
-describe '#type(key)' do
+RSpec.describe '#type(key)' do
   before do
     @key = 'mock-redis-test:type'
   end
 
   it "returns 'none' for no key" do
-    @redises.type(@key).should == 'none'
+    expect(@redises.type(@key)).to eq('none')
   end
 
   it "returns 'string' for a string" do
     @redises.set(@key, 'stringlish')
-    @redises.type(@key).should == 'string'
+    expect(@redises.type(@key)).to eq('string')
   end
 
   it "returns 'list' for a list" do
     @redises.lpush(@key, 100)
-    @redises.type(@key).should == 'list'
+    expect(@redises.type(@key)).to eq('list')
   end
 
   it "returns 'hash' for a hash" do
     @redises.hset(@key, 100, 200)
-    @redises.type(@key).should == 'hash'
+    expect(@redises.type(@key)).to eq('hash')
   end
 
   it "returns 'set' for a set" do
     @redises.sadd(@key, 100)
-    @redises.type(@key).should == 'set'
+    expect(@redises.type(@key)).to eq('set')
   end
 
   it "returns 'zset' for a zset" do
     @redises.zadd(@key, 1, 2)
-    @redises.type(@key).should == 'zset'
+    expect(@redises.type(@key)).to eq('zset')
   end
 end

--- a/spec/commands/unwatch_spec.rb
+++ b/spec/commands/unwatch_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe '#unwatch' do
+RSpec.describe '#unwatch' do
   it "responds with 'OK'" do
-    @redises.unwatch.should == 'OK'
+    expect(@redises.unwatch).to eq('OK')
   end
 end

--- a/spec/commands/watch_spec.rb
+++ b/spec/commands/watch_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe '#watch(key [, key, ...)' do
+RSpec.describe '#watch(key [, key, ...)' do
   before do
     @key1 = 'mock-redis-test-watch1'
     @key2 = 'mock-redis-test-watch2'
   end
 
   it "returns 'OK'" do
-    @redises.watch(@key1, @key2).should == 'OK'
+    expect(@redises.watch(@key1, @key2)).to eq('OK')
   end
 
   it 'EXECs its MULTI on successes' do
@@ -16,6 +16,6 @@ describe '#watch(key [, key, ...)' do
         multi.set 'bar', 'baz'
       end
     end
-    @redises.get('bar').should eq('baz')
+    expect(@redises.get('bar')).to eq('baz')
   end
 end

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, approximate: true)' do
+RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, '\
+               'id: "0-0", maxlen: 1000, approximate: true)' do
   before :all do
     sleep 1 - (Time.now.to_f % 1)
     @key = 'mock-redis-test:xadd'

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, approximate: true)' do
+RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, approximate: true)' do
   before :all do
     sleep 1 - (Time.now.to_f % 1)
     @key = 'mock-redis-test:xadd'

--- a/spec/commands/xlen_spec.rb
+++ b/spec/commands/xlen_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xlen(key)' do
+RSpec.describe '#xlen(key)' do
   before :all do
     sleep 1 - (Time.now.to_f % 1)
     @key = 'mock-redis-test:xlen'

--- a/spec/commands/xrange_spec.rb
+++ b/spec/commands/xrange_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xrange("mystream", first: "0-1", last: "0-3", count: 10)' do
+RSpec.describe '#xrange("mystream", first: "0-1", last: "0-3", count: 10)' do
   before { @key = 'mock-redis-test:xrange' }
 
   it 'finds an empty range' do

--- a/spec/commands/xread_spec.rb
+++ b/spec/commands/xread_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xread(keys, ids)' do
+RSpec.describe '#xread(keys, ids)' do
   before :all do
     sleep 1 - (Time.now.to_f % 1)
     @key = 'mock-redis-test:xread'

--- a/spec/commands/xrevrange_spec.rb
+++ b/spec/commands/xrevrange_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xrevrange(key, start, end)' do
+RSpec.describe '#xrevrange(key, start, end)' do
   before { @key = 'mock-redis-test:xrevrange' }
 
   it 'finds an empty range' do

--- a/spec/commands/xtrim_spec.rb
+++ b/spec/commands/xtrim_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#xtrim("mystream", 1000, approximate: true)' do
+RSpec.describe '#xtrim("mystream", 1000, approximate: true)' do
   before { @key = 'mock-redis-test:xtrim' }
 
   before :each do

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -1,127 +1,127 @@
 require 'spec_helper'
 
-describe '#zadd(key, score, member)' do
+RSpec.describe '#zadd(key, score, member)' do
   before { @key = 'mock-redis-test:zadd' }
 
   it "returns true if member wasn't present in the set" do
-    @redises.zadd(@key, 1, 'foo').should == true
+    expect(@redises.zadd(@key, 1, 'foo')).to eq(true)
   end
 
   it 'returns false if member was present in the set' do
     @redises.zadd(@key, 1, 'foo')
-    @redises.zadd(@key, 1, 'foo').should == false
+    expect(@redises.zadd(@key, 1, 'foo')).to eq(false)
   end
 
   it 'adds member to the set' do
     @redises.zadd(@key, 1, 'foo')
-    @redises.zrange(@key, 0, -1).should == ['foo']
+    expect(@redises.zrange(@key, 0, -1)).to eq(['foo'])
   end
 
   it 'treats integer members as strings' do
     member = 11
     @redises.zadd(@key, 1, member)
-    @redises.zrange(@key, 0, -1).should == [member.to_s]
+    expect(@redises.zrange(@key, 0, -1)).to eq([member.to_s])
   end
 
   it 'allows scores to be set to Float::INFINITY' do
     member = '1'
     @redises.zadd(@key, Float::INFINITY, member)
-    @redises.zrange(@key, 0, -1).should == [member]
+    expect(@redises.zrange(@key, 0, -1)).to eq([member])
   end
 
   it 'updates the score' do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'foo')
 
-    @redises.zscore(@key, 'foo').should == 2.0
+    expect(@redises.zscore(@key, 'foo')).to eq(2.0)
   end
 
   it 'with XX option command do nothing if element not exist' do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'bar', xx: true)
-    @redises.zrange(@key, 0, -1).should_not include 'bar'
+    expect(@redises.zrange(@key, 0, -1)).not_to include 'bar'
   end
 
   it 'with XX option command update index on exist element' do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'foo', xx: true)
-    @redises.zscore(@key, 'foo').should == 2.0
+    expect(@redises.zscore(@key, 'foo')).to eq(2.0)
   end
 
   it 'with XX option and multiple elements command update index on exist element' do
     @redises.zadd(@key, 1, 'foo')
     added_count = @redises.zadd(@key, [[2, 'foo'], [2, 'bar']], xx: true)
-    added_count.should == 0
+    expect(added_count).to eq(0)
 
-    @redises.zscore(@key, 'foo').should == 2.0
-    @redises.zrange(@key, 0, -1).should_not include 'bar'
+    expect(@redises.zscore(@key, 'foo')).to eq(2.0)
+    expect(@redises.zrange(@key, 0, -1)).not_to include 'bar'
   end
 
   it "with NX option don't update current element" do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'foo', nx: true)
-    @redises.zscore(@key, 'foo').should == 1.0
+    expect(@redises.zscore(@key, 'foo')).to eq(1.0)
   end
 
   it 'with NX option create new element' do
     @redises.zadd(@key, 1, 'foo')
     @redises.zadd(@key, 2, 'bar', nx: true)
-    @redises.zrange(@key, 0, -1).should include 'bar'
+    expect(@redises.zrange(@key, 0, -1)).to include 'bar'
   end
 
   it 'with NX option and multiple elements command only create element' do
     @redises.zadd(@key, 1, 'foo')
     added_count = @redises.zadd(@key, [[2, 'foo'], [2, 'bar']], nx: true)
-    added_count.should == 1
-    @redises.zscore(@key, 'bar').should == 2.0
-    @redises.zrange(@key, 0, -1).should eq %w[foo bar]
+    expect(added_count).to eq(1)
+    expect(@redises.zscore(@key, 'bar')).to eq(2.0)
+    expect(@redises.zrange(@key, 0, -1)).to eq %w[foo bar]
   end
 
   it 'XX and NX options in same time raise error' do
-    lambda do
+    expect do
       @redises.zadd(@key, 1, 'foo', nx: true, xx: true)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'with INCR is act like zincrby' do
-    @redises.zadd(@key, 10, 'bert', incr: true).should == 10.0
-    @redises.zadd(@key, 3, 'bert', incr: true).should == 13.0
+    expect(@redises.zadd(@key, 10, 'bert', incr: true)).to eq(10.0)
+    expect(@redises.zadd(@key, 3, 'bert', incr: true)).to eq(13.0)
   end
 
   it 'with INCR and XX not create element' do
-    @redises.zadd(@key, 10, 'bert', xx: true, incr: true).should be_nil
+    expect(@redises.zadd(@key, 10, 'bert', xx: true, incr: true)).to be_nil
   end
 
   it 'with INCR and XX increase score for exist element' do
     @redises.zadd(@key, 2, 'bert')
-    @redises.zadd(@key, 10, 'bert', xx: true, incr: true).should == 12.0
+    expect(@redises.zadd(@key, 10, 'bert', xx: true, incr: true)).to eq(12.0)
   end
 
   it 'with INCR and NX create element with score' do
-    @redises.zadd(@key, 11, 'bert', nx: true, incr: true).should == 11.0
+    expect(@redises.zadd(@key, 11, 'bert', nx: true, incr: true)).to eq(11.0)
   end
 
   it 'with INCR and NX not update element' do
     @redises.zadd(@key, 1, 'bert')
-    @redises.zadd(@key, 10, 'bert', nx: true, incr: true).should be_nil
+    expect(@redises.zadd(@key, 10, 'bert', nx: true, incr: true)).to be_nil
   end
 
   it 'with INCR with variable number of arguments raise error' do
-    lambda do
+    expect do
       @redises.zadd(@key, [[1, 'one'], [2, 'two']], incr: true)
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it 'supports a variable number of arguments' do
     @redises.zadd(@key, [[1, 'one'], [2, 'two']])
     @redises.zadd(@key, [[3, 'three']])
-    @redises.zrange(@key, 0, -1).should == %w[one two three]
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[one two three])
   end
 
   it 'raises an error if an empty array is given' do
-    lambda do
+    expect do
       @redises.zadd(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'arg 1 is a score'

--- a/spec/commands/zcard_spec.rb
+++ b/spec/commands/zcard_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zcard(key)' do
+RSpec.describe '#zcard(key)' do
   before do
     @key = 'mock-redis-test:zcard'
   end
@@ -8,11 +8,11 @@ describe '#zcard(key)' do
   it 'returns the number of elements in the zset' do
     @redises.zadd(@key, 1, 'Washington')
     @redises.zadd(@key, 2, 'Adams')
-    @redises.zcard(@key).should == 2
+    expect(@redises.zcard(@key)).to eq(2)
   end
 
   it 'returns 0 for nonexistent sets' do
-    @redises.zcard(@key).should == 0
+    expect(@redises.zcard(@key)).to eq(0)
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zcount_spec.rb
+++ b/spec/commands/zcount_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zcount(key, min, max)' do
+RSpec.describe '#zcount(key, min, max)' do
   before do
     @key = 'mock-redis-test:zcount'
     @redises.zadd(@key, 1, 'Washington')
@@ -10,27 +10,27 @@ describe '#zcount(key, min, max)' do
   end
 
   it 'returns the number of members in the zset with scores in (min..max)' do
-    @redises.zcount(@key, 3, 10).should == 2
+    expect(@redises.zcount(@key, 3, 10)).to eq(2)
   end
 
   it 'returns 0 if there are no such members' do
-    @redises.zcount(@key, 100, 200).should == 0
+    expect(@redises.zcount(@key, 100, 200)).to eq(0)
   end
 
   it 'returns count of all elements when -inf to +inf' do
-    @redises.zcount(@key, '-inf', '+inf').should == 4
+    expect(@redises.zcount(@key, '-inf', '+inf')).to eq(4)
   end
 
   it 'returns a proper count of elements using +inf upper bound' do
-    @redises.zcount(@key, 3, '+inf').should == 2
+    expect(@redises.zcount(@key, 3, '+inf')).to eq(2)
   end
 
   it 'returns a proper count of elements using exclusive lower bound' do
-    @redises.zcount(@key, '(3', '+inf').should == 1
+    expect(@redises.zcount(@key, '(3', '+inf')).to eq(1)
   end
 
   it 'returns a proper count of elements using exclusive upper bound' do
-    @redises.zcount(@key, '-inf', '(3').should == 2
+    expect(@redises.zcount(@key, '-inf', '(3')).to eq(2)
   end
 
   it_should_behave_like 'arg 1 is a score'

--- a/spec/commands/zincrby_spec.rb
+++ b/spec/commands/zincrby_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-describe '#zincrby(key, increment, member)' do
+RSpec.describe '#zincrby(key, increment, member)' do
   before do
     @key = 'mock-redis-test:zincrby'
     @redises.zadd(@key, 1, 'bert')
   end
 
   it 'returns the new score as a string' do
-    @redises.zincrby(@key, 10, 'bert').should == 11.0
+    expect(@redises.zincrby(@key, 10, 'bert')).to eq(11.0)
   end
 
   it "updates the item's score" do
     @redises.zincrby(@key, 10, 'bert')
-    @redises.zscore(@key, 'bert').should == 11.0
+    expect(@redises.zscore(@key, 'bert')).to eq(11.0)
   end
 
   it 'handles integer members correctly' do
     member = 11
     @redises.zadd(@key, 1, member)
     @redises.zincrby(@key, 1, member)
-    @redises.zscore(@key, member).should == 2.0
+    expect(@redises.zscore(@key, member)).to eq(2.0)
   end
 
   it 'adds missing members with score increment' do
-    @redises.zincrby(@key, 5.5, 'bigbird').should == 5.5
+    expect(@redises.zincrby(@key, 5.5, 'bigbird')).to eq(5.5)
   end
 
   it_should_behave_like 'arg 1 is a score'

--- a/spec/commands/zinterstore_spec.rb
+++ b/spec/commands/zinterstore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
+RSpec.describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
   before do
     @odds   = 'mock-redis-test:zinterstore:odds'
     @primes = 'mock-redis-test:zinterstore:primes'
@@ -19,27 +19,29 @@ describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
   end
 
   it 'returns the number of elements in the new set' do
-    @redises.zinterstore(@dest, [@odds, @primes]).should == 3
+    expect(@redises.zinterstore(@dest, [@odds, @primes])).to eq(3)
   end
 
   it "sums the members' scores by default" do
     @redises.zinterstore(@dest, [@odds, @primes])
-    @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+    expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
       [['three', 6.0], ['five', 10.0], ['seven', 14.0]]
+    )
   end
 
   it 'removes existing elements in destination' do
     @redises.zadd(@dest, 10, 'ten')
 
     @redises.zinterstore(@dest, [@primes])
-    @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+    expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
       [['two', 2.0], ['three', 3.0], ['five', 5.0], ['seven', 7.0]]
+    )
   end
 
   it 'raises an error if keys is empty' do
-    lambda do
+    expect do
       @redises.zinterstore(@dest, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   context 'when used with a set' do
@@ -53,13 +55,14 @@ describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
     end
 
     it 'returns the number of elements in the new set' do
-      @redises.zinterstore(@dest, [@odds, @primes_text]).should == 3
+      expect(@redises.zinterstore(@dest, [@odds, @primes_text])).to eq(3)
     end
 
     it 'sums the scores, substituting 1.0 for set values' do
       @redises.zinterstore(@dest, [@odds, @primes_text])
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['three', 4.0], ['five', 6.0], ['seven', 8.0]]
+      )
     end
   end
 
@@ -70,23 +73,24 @@ describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
       @redises.set(@non_set, 'one')
     end
     it 'raises an error for wrong value type' do
-      lambda do
+      expect do
         @redises.zinterstore(@dest, [@odds, @non_set])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
   context 'the :weights argument' do
     it 'multiplies the scores by the weights while aggregating' do
       @redises.zinterstore(@dest, [@odds, @primes], :weights => [2, 3])
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['three', 15.0], ['five', 25.0], ['seven', 35.0]]
+      )
     end
 
     it 'raises an error if the number of weights != the number of keys' do
-      lambda do
+      expect do
         @redises.zinterstore(@dest, [@odds, @primes], :weights => [1, 2, 3])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
@@ -103,28 +107,30 @@ describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
 
     it 'aggregates scores with min when :aggregate => :min is specified' do
       @redises.zinterstore(@dest, [@bigs, @smalls], :aggregate => :min)
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['bert', 1.0], ['ernie', 2.0]]
+      )
     end
 
     it 'aggregates scores with max when :aggregate => :max is specified' do
       @redises.zinterstore(@dest, [@bigs, @smalls], :aggregate => :max)
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['bert', 100.0], ['ernie', 200.0]]
+      )
     end
 
     it "allows 'min', 'MIN', etc. as aliases for :min" do
       @redises.zinterstore(@dest, [@bigs, @smalls], :aggregate => 'min')
-      @redises.zscore(@dest, 'bert').should == 1.0
+      expect(@redises.zscore(@dest, 'bert')).to eq(1.0)
 
       @redises.zinterstore(@dest, [@bigs, @smalls], :aggregate => 'MIN')
-      @redises.zscore(@dest, 'bert').should == 1.0
+      expect(@redises.zscore(@dest, 'bert')).to eq(1.0)
     end
 
     it 'raises an error for unknown aggregation function' do
-      lambda do
+      expect do
         @redises.zinterstore(@dest, [@bigs, @smalls], :aggregate => :mix)
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 end

--- a/spec/commands/zinterstore_spec.rb
+++ b/spec/commands/zinterstore_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe '#zinterstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
+RSpec.describe '#zinterstore(destination, keys, '\
+               '[:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
   before do
     @odds   = 'mock-redis-test:zinterstore:odds'
     @primes = 'mock-redis-test:zinterstore:primes'

--- a/spec/commands/zpopmax_spec.rb
+++ b/spec/commands/zpopmax_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zpopmax(key, count)' do
+RSpec.describe '#zpopmax(key, count)' do
   before(:each) do
     @key = 'mock-redis-test:zpopmax'
     @redises.del(@key)
@@ -11,12 +11,12 @@ describe '#zpopmax(key, count)' do
 
   context 'when count is unspecified' do
     it 'returns nil if the set does not exist' do
-      @redises.zpopmax('does-not-exist').should nil
+      expect(@redises.zpopmax('does-not-exist')).to be_nil
     end
 
     it 'returns the highest ranked element' do
-      @redises.zpopmax(@key).should == ['three', 3]
-      @redises.zcard(@key).should == 2
+      expect(@redises.zpopmax(@key)).to eq(['three', 3])
+      expect(@redises.zcard(@key)).to eq(2)
     end
   end
 
@@ -24,12 +24,12 @@ describe '#zpopmax(key, count)' do
     let(:count) { 1 }
 
     it 'returns nil if the set does not exist' do
-      @redises.zpopmax('does-not-exist', count).should nil
+      expect(@redises.zpopmax('does-not-exist', count)).to be_nil
     end
 
     it 'returns the highest ranked element' do
-      @redises.zpopmax(@key, count).should == ['three', 3]
-      @redises.zcard(@key).should == 2
+      expect(@redises.zpopmax(@key, count)).to eq(['three', 3])
+      expect(@redises.zcard(@key)).to eq(2)
     end
   end
 
@@ -37,12 +37,12 @@ describe '#zpopmax(key, count)' do
     let(:count) { 2 }
 
     it 'returns empty array if the set does not exist' do
-      @redises.zpopmax('does-not-exist', count).should == []
+      expect(@redises.zpopmax('does-not-exist', count)).to eq([])
     end
 
     it 'returns the highest ranked elements' do
-      @redises.zpopmax(@key, count).should == [['three', 3], ['two', 2]]
-      @redises.zcard(@key).should == 1
+      expect(@redises.zpopmax(@key, count)).to eq([['three', 3], ['two', 2]])
+      expect(@redises.zcard(@key)).to eq(1)
     end
   end
 
@@ -51,8 +51,8 @@ describe '#zpopmax(key, count)' do
 
     it 'returns the entire set' do
       before = @redises.zrange(@key, 0, count, with_scores: true).reverse
-      @redises.zpopmax(@key, count).should == before
-      @redises.zcard(@key).should == 0
+      expect(@redises.zpopmax(@key, count)).to eq(before)
+      expect(@redises.zcard(@key)).to eq(0)
     end
   end
 

--- a/spec/commands/zpopmin_spec.rb
+++ b/spec/commands/zpopmin_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zpopmin(key, count)' do
+RSpec.describe '#zpopmin(key, count)' do
   before(:each) do
     @key = 'mock-redis-test:zpopmin'
     @redises.del(@key)
@@ -11,12 +11,12 @@ describe '#zpopmin(key, count)' do
 
   context 'when count is unspecified' do
     it 'returns nil if the set does not exist' do
-      @redises.zpopmin('does-not-exist').should nil
+      expect(@redises.zpopmin('does-not-exist')).to be_nil
     end
 
     it 'returns the lowest ranked element' do
-      @redises.zpopmin(@key).should == ['one', 1]
-      @redises.zcard(@key).should == 2
+      expect(@redises.zpopmin(@key)).to eq(['one', 1])
+      expect(@redises.zcard(@key)).to eq(2)
     end
   end
 
@@ -24,12 +24,12 @@ describe '#zpopmin(key, count)' do
     let(:count) { 1 }
 
     it 'returns nil if the set does not exist' do
-      @redises.zpopmin('does-not-exist', count).should nil
+      expect(@redises.zpopmin('does-not-exist', count)).to be_nil
     end
 
     it 'returns the lowest ranked element' do
-      @redises.zpopmin(@key, count).should == ['one', 1]
-      @redises.zcard(@key).should == 2
+      expect(@redises.zpopmin(@key, count)).to eq(['one', 1])
+      expect(@redises.zcard(@key)).to eq(2)
     end
   end
 
@@ -37,12 +37,12 @@ describe '#zpopmin(key, count)' do
     let(:count) { 2 }
 
     it 'returns empty array if the set does not exist' do
-      @redises.zpopmin('does-not-exist', count).should == []
+      expect(@redises.zpopmin('does-not-exist', count)).to eq([])
     end
 
     it 'returns the lowest ranked elements' do
-      @redises.zpopmin(@key, count).should == [['one', 1], ['two', 2]]
-      @redises.zcard(@key).should == 1
+      expect(@redises.zpopmin(@key, count)).to eq([['one', 1], ['two', 2]])
+      expect(@redises.zcard(@key)).to eq(1)
     end
   end
 
@@ -51,8 +51,8 @@ describe '#zpopmin(key, count)' do
 
     it 'returns the entire set' do
       before = @redises.zrange(@key, 0, count, with_scores: true)
-      @redises.zpopmin(@key, count).should == before
-      @redises.zcard(@key).should == 0
+      expect(@redises.zpopmin(@key, count)).to eq(before)
+      expect(@redises.zcard(@key)).to eq(0)
     end
   end
 

--- a/spec/commands/zrange_spec.rb
+++ b/spec/commands/zrange_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrange(key, start, stop [, :with_scores => true])' do
+RSpec.describe '#zrange(key, start, stop [, :with_scores => true])' do
   before do
     @key = 'mock-redis-test:zrange'
     @redises.zadd(@key, 3, 'Jefferson')
@@ -15,17 +15,17 @@ describe '#zrange(key, start, stop [, :with_scores => true])' do
     end
 
     it 'should return an empty array' do
-      @redises.exists?(@key).should == false
-      @redises.zrange(@key, 0, 4).should == []
+      expect(@redises.exists?(@key)).to eq(false)
+      expect(@redises.zrange(@key, 0, 4)).to eq([])
     end
   end
 
   it 'returns the elements when the range is given as strings' do
-    @redises.zrange(@key, '0', '1').should == %w[Washington Adams]
+    expect(@redises.zrange(@key, '0', '1')).to eq(%w[Washington Adams])
   end
 
   it 'returns the elements in order by score' do
-    @redises.zrange(@key, 0, 1).should == %w[Washington Adams]
+    expect(@redises.zrange(@key, 0, 1)).to eq(%w[Washington Adams])
   end
 
   context 'when a subset of elements have the same score' do
@@ -34,46 +34,46 @@ describe '#zrange(key, start, stop [, :with_scores => true])' do
     end
 
     it 'returns the elements in ascending lexicographical order' do
-      @redises.zrange(@key, 0, 1).should == %w[Martha Washington]
+      expect(@redises.zrange(@key, 0, 1)).to eq(%w[Martha Washington])
     end
   end
 
   it 'returns the elements in order by score (negative indices)' do
-    @redises.zrange(@key, -2, -1).should == %w[Jefferson Madison]
+    expect(@redises.zrange(@key, -2, -1)).to eq(%w[Jefferson Madison])
   end
 
   it 'returns empty list when start is too large' do
-    @redises.zrange(@key, 5, -1).should == []
+    expect(@redises.zrange(@key, 5, -1)).to eq([])
   end
 
   it 'returns entire list when start is out of bounds with negative end in bounds' do
-    @redises.zrange(@key, -5, -1).should == %w[Washington Adams Jefferson Madison]
+    expect(@redises.zrange(@key, -5, -1)).to eq(%w[Washington Adams Jefferson Madison])
   end
 
   it 'returns correct subset when start is out of bounds with positive end in bounds' do
-    @redises.zrange(@key, -5, 1).should == %w[Washington Adams]
+    expect(@redises.zrange(@key, -5, 1)).to eq(%w[Washington Adams])
   end
 
   it 'returns empty list when start is in bounds with negative end out of bounds' do
-    @redises.zrange(@key, 1, -5).should == []
+    expect(@redises.zrange(@key, 1, -5)).to eq([])
   end
 
   it 'returns empty list when start is 0 with negative end out of bounds' do
-    @redises.zrange(@key, 0, -5).should == []
+    expect(@redises.zrange(@key, 0, -5)).to eq([])
   end
 
   it 'returns correct subset when start is in bounds with negative end in bounds' do
-    @redises.zrange(@key, 1, -1).should == %w[Adams Jefferson Madison]
+    expect(@redises.zrange(@key, 1, -1)).to eq(%w[Adams Jefferson Madison])
   end
 
   it 'returns the scores when :with_scores is specified' do
-    @redises.zrange(@key, 0, 1, :with_scores => true).
-      should == [['Washington', 1.0], ['Adams', 2.0]]
+    expect(@redises.zrange(@key, 0, 1, :with_scores => true)).
+      to eq([['Washington', 1.0], ['Adams', 2.0]])
   end
 
   it 'returns the scores when :withscores is specified' do
-    @redises.zrange(@key, 0, 1, :withscores => true).
-      should == [['Washington', 1.0], ['Adams', 2.0]]
+    expect(@redises.zrange(@key, 0, 1, :withscores => true)).
+      to eq([['Washington', 1.0], ['Adams', 2.0]])
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrangebyscore_spec.rb
+++ b/spec/commands/zrangebyscore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
+RSpec.describe '#zrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
   before do
     @key = 'mock-redis-test:zrangebyscore'
     @redises.zadd(@key, 1, 'Washington')
@@ -15,68 +15,69 @@ describe '#zrangebyscore(key, start, stop [:with_scores => true] [:limit => [off
     end
 
     it 'should return an empty array' do
-      @redises.exists?(@key).should == false
-      @redises.zrangebyscore(@key, 0, 4).should == []
+      expect(@redises.exists?(@key)).to eq(false)
+      expect(@redises.zrangebyscore(@key, 0, 4)).to eq([])
     end
   end
 
   it 'returns the elements in order by score' do
-    @redises.zrangebyscore(@key, 1, 2).should == %w[Washington Adams]
+    expect(@redises.zrangebyscore(@key, 1, 2)).to eq(%w[Washington Adams])
   end
 
   it 'returns the scores when :with_scores is specified' do
-    @redises.zrangebyscore(@key, 1, 2, :with_scores => true).
-      should == [['Washington', 1.0], ['Adams', 2.0]]
+    expect(@redises.zrangebyscore(@key, 1, 2, :with_scores => true)).
+      to eq([['Washington', 1.0], ['Adams', 2.0]])
   end
 
   it 'returns the scores when :withscores is specified' do
-    @redises.zrangebyscore(@key, 1, 2, :withscores => true).
-      should == [['Washington', 1.0], ['Adams', 2.0]]
+    expect(@redises.zrangebyscore(@key, 1, 2, :withscores => true)).
+      to eq([['Washington', 1.0], ['Adams', 2.0]])
   end
 
   it 'honors the :limit => [offset count] argument' do
-    @redises.zrangebyscore(@key, -100, 100, :limit => [1, 2]).
-      should == %w[Adams Jefferson]
+    expect(@redises.zrangebyscore(@key, -100, 100, :limit => [1, 2])).
+      to eq(%w[Adams Jefferson])
   end
 
   it "raises an error if :limit isn't a 2-tuple" do
-    lambda do
+    expect do
       @redises.zrangebyscore(@key, -100, 100, :limit => [1, 2, 3])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.zrangebyscore(@key, -100, 100, :limit => '1, 2')
-    end.should raise_error(RedisMultiplexer::MismatchedResponse)
+    end.to raise_error(RedisMultiplexer::MismatchedResponse)
   end
 
   it 'treats scores like floats, not strings' do
     @redises.zadd(@key, '10', 'Tyler')
-    @redises.zrangebyscore(@key, 1, 2).should == %w[Washington Adams]
+    expect(@redises.zrangebyscore(@key, 1, 2)).to eq(%w[Washington Adams])
   end
 
   it 'treats -inf as negative infinity' do
-    @redises.zrangebyscore(@key, '-inf', 3).should ==
+    expect(@redises.zrangebyscore(@key, '-inf', 3)).to eq(
       %w[Washington Adams Jefferson]
+    )
   end
 
   it 'treats +inf as positive infinity' do
-    @redises.zrangebyscore(@key, 3, '+inf').should == %w[Jefferson Madison]
+    expect(@redises.zrangebyscore(@key, 3, '+inf')).to eq(%w[Jefferson Madison])
   end
 
   it 'treats +inf as positive infinity' do
-    @redises.zrangebyscore(@key, 3, '+inf').should == %w[Jefferson Madison]
+    expect(@redises.zrangebyscore(@key, 3, '+inf')).to eq(%w[Jefferson Madison])
   end
 
   it 'honors exclusive ranges on the left' do
-    @redises.zrangebyscore(@key, '(3', 4).should == ['Madison']
+    expect(@redises.zrangebyscore(@key, '(3', 4)).to eq(['Madison'])
   end
 
   it 'honors exclusive ranges on the right' do
-    @redises.zrangebyscore(@key, '3', '(4').should == ['Jefferson']
+    expect(@redises.zrangebyscore(@key, '3', '(4')).to eq(['Jefferson'])
   end
 
   it 'honors exclusive ranges on the left and the right simultaneously' do
-    @redises.zrangebyscore(@key, '(1', '(4').should == %w[Adams Jefferson]
+    expect(@redises.zrangebyscore(@key, '(1', '(4')).to eq(%w[Adams Jefferson])
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrangebyscore_spec.rb
+++ b/spec/commands/zrangebyscore_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe '#zrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
+RSpec.describe '#zrangebyscore(key, start, stop '\
+               '[:with_scores => true] [:limit => [offset count]])' do
   before do
     @key = 'mock-redis-test:zrangebyscore'
     @redises.zadd(@key, 1, 'Washington')

--- a/spec/commands/zrank_spec.rb
+++ b/spec/commands/zrank_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrank(key, member)' do
+RSpec.describe '#zrank(key, member)' do
   before do
     @key = 'mock-redis-test:zrank'
 
@@ -10,19 +10,19 @@ describe '#zrank(key, member)' do
   end
 
   it "returns nil if member wasn't present in the set" do
-    @redises.zrank(@key, 'foo').should be_nil
+    expect(@redises.zrank(@key, 'foo')).to be_nil
   end
 
   it 'returns the index of the member in the set' do
-    @redises.zrank(@key, 'one').should == 0
-    @redises.zrank(@key, 'two').should == 1
-    @redises.zrank(@key, 'three').should == 2
+    expect(@redises.zrank(@key, 'one')).to eq(0)
+    expect(@redises.zrank(@key, 'two')).to eq(1)
+    expect(@redises.zrank(@key, 'three')).to eq(2)
   end
 
   it 'handles integer members correctly' do
     member = 11
     @redises.zadd(@key, 4, member)
-    @redises.zrank(@key, member).should == 3
+    expect(@redises.zrank(@key, member)).to eq(3)
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrem_spec.rb
+++ b/spec/commands/zrem_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrem(key, member)' do
+RSpec.describe '#zrem(key, member)' do
   before do
     @key = 'mock-redis-test:zrem'
 
@@ -9,41 +9,41 @@ describe '#zrem(key, member)' do
   end
 
   it 'returns true if member is present in the set' do
-    @redises.zrem(@key, 'one').should == true
+    expect(@redises.zrem(@key, 'one')).to eq(true)
   end
 
   it 'returns false if member is not present in the set' do
-    @redises.zrem(@key, 'nobody home').should == false
+    expect(@redises.zrem(@key, 'nobody home')).to eq(false)
   end
 
   it 'removes member from the set' do
     @redises.zrem(@key, 'one')
-    @redises.zrange(@key, 0, -1).should == ['two']
+    expect(@redises.zrange(@key, 0, -1)).to eq(['two'])
   end
 
   it 'removes integer member from the set' do
     member = 11
     @redises.zadd(@key, 3, member)
-    @redises.zrem(@key, member).should == true
-    @redises.zrange(@key, 0, -1).should == %w[one two]
+    expect(@redises.zrem(@key, member)).to eq(true)
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[one two])
   end
 
   it 'removes integer members inside an array from the set' do
     member = 11
     @redises.zadd(@key, 3, member)
-    @redises.zrem(@key, [member]).should == 1
-    @redises.zrange(@key, 0, -1).should == %w[one two]
+    expect(@redises.zrem(@key, [member])).to eq(1)
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[one two])
   end
 
   it 'supports a variable number of arguments' do
     @redises.zrem(@key, %w[one two])
-    @redises.zrange(@key, 0, -1).should be_empty
+    expect(@redises.zrange(@key, 0, -1)).to be_empty
   end
 
   it 'raises an error if member is an empty array' do
-    lambda do
+    expect do
       @redises.zrem(@key, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zremrangebyrank_spec.rb
+++ b/spec/commands/zremrangebyrank_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zremrangebyrank(key, start, stop)' do
+RSpec.describe '#zremrangebyrank(key, start, stop)' do
   before do
     @key = 'mock-redis-test:zremrangebyrank'
     @redises.zadd(@key, 1, 'Washington')
@@ -10,17 +10,17 @@ describe '#zremrangebyrank(key, start, stop)' do
   end
 
   it 'returns the number of elements in range' do
-    @redises.zremrangebyrank(@key, 2, 3).should == 2
+    expect(@redises.zremrangebyrank(@key, 2, 3)).to eq(2)
   end
 
   it 'removes the elements' do
     @redises.zremrangebyrank(@key, 2, 3)
-    @redises.zrange(@key, 0, -1).should == %w[Washington Adams]
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[Washington Adams])
   end
 
   it 'does nothing if start is greater than cardinality of set' do
     @redises.zremrangebyrank(@key, 5, -1)
-    @redises.zrange(@key, 0, -1).should == %w[Washington Adams Jefferson Madison]
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[Washington Adams Jefferson Madison])
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zremrangebyscore_spec.rb
+++ b/spec/commands/zremrangebyscore_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'date'
 
-describe '#zremrangebyscore(key, min, max)' do
+RSpec.describe '#zremrangebyscore(key, min, max)' do
   before do
     @key = 'mock-redis-test:zremrangebyscore'
     @redises.zadd(@key, 1, 'Washington')
@@ -11,18 +11,18 @@ describe '#zremrangebyscore(key, min, max)' do
   end
 
   it 'returns the number of elements in range' do
-    @redises.zremrangebyscore(@key, 2, 3).should == 2
+    expect(@redises.zremrangebyscore(@key, 2, 3)).to eq(2)
   end
 
   it 'removes the elements' do
     @redises.zremrangebyscore(@key, 2, 3)
-    @redises.zrange(@key, 0, -1).should == %w[Washington Madison]
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[Washington Madison])
   end
 
   # As seen in http://redis.io/commands/zremrangebyscore
   it 'removes the elements for complex statements' do
     @redises.zremrangebyscore(@key, '-inf', '(4')
-    @redises.zrange(@key, 0, -1).should == %w[Madison]
+    expect(@redises.zrange(@key, 0, -1)).to eq(%w[Madison])
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrevrange_spec.rb
+++ b/spec/commands/zrevrange_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrevrange(key, start, stop [, :with_scores => true])' do
+RSpec.describe '#zrevrange(key, start, stop [, :with_scores => true])' do
   before do
     @key = 'mock-redis-test:zrevrange'
     @redises.zadd(@key, 1, 'Washington')
@@ -15,13 +15,13 @@ describe '#zrevrange(key, start, stop [, :with_scores => true])' do
     end
 
     it 'should return an empty array' do
-      @redises.exists?(@key).should == false
-      @redises.zrevrange(@key, 0, 4).should == []
+      expect(@redises.exists?(@key)).to eq(false)
+      expect(@redises.zrevrange(@key, 0, 4)).to eq([])
     end
   end
 
   it 'returns the elements in order by score' do
-    @redises.zrevrange(@key, 0, 1).should == %w[Madison Jefferson]
+    expect(@redises.zrevrange(@key, 0, 1)).to eq(%w[Madison Jefferson])
   end
 
   context 'when a subset of elements have the same score' do
@@ -30,26 +30,26 @@ describe '#zrevrange(key, start, stop [, :with_scores => true])' do
     end
 
     it 'returns the elements in descending lexicographical order' do
-      @redises.zrevrange(@key, 3, 4).should == %w[Washington Martha]
+      expect(@redises.zrevrange(@key, 3, 4)).to eq(%w[Washington Martha])
     end
   end
 
   it 'returns the elements in order by score (negative indices)' do
-    @redises.zrevrange(@key, -2, -1).should == %w[Adams Washington]
+    expect(@redises.zrevrange(@key, -2, -1)).to eq(%w[Adams Washington])
   end
 
   it 'returns empty list when start is too large' do
-    @redises.zrevrange(@key, 5, -1).should == []
+    expect(@redises.zrevrange(@key, 5, -1)).to eq([])
   end
 
   it 'returns the scores when :with_scores is specified' do
-    @redises.zrevrange(@key, 2, 3, :with_scores => true).
-      should == [['Adams', 2.0], ['Washington', 1.0]]
+    expect(@redises.zrevrange(@key, 2, 3, :with_scores => true)).
+      to eq([['Adams', 2.0], ['Washington', 1.0]])
   end
 
   it 'returns the scores when :withscores is specified' do
-    @redises.zrevrange(@key, 2, 3, :withscores => true).
-      should == [['Adams', 2.0], ['Washington', 1.0]]
+    expect(@redises.zrevrange(@key, 2, 3, :withscores => true)).
+      to eq([['Adams', 2.0], ['Washington', 1.0]])
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrevrangebyscore_spec.rb
+++ b/spec/commands/zrevrangebyscore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrevrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
+RSpec.describe '#zrevrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
   before do
     @key = 'mock-redis-test:zrevrangebyscore'
     @redises.zadd(@key, 1, 'Washington')
@@ -15,43 +15,43 @@ describe '#zrevrangebyscore(key, start, stop [:with_scores => true] [:limit => [
     end
 
     it 'should return an empty array' do
-      @redises.exists?(@key).should == false
-      @redises.zrevrangebyscore(@key, 0, 4).should == []
+      expect(@redises.exists?(@key)).to eq(false)
+      expect(@redises.zrevrangebyscore(@key, 0, 4)).to eq([])
     end
   end
 
   it 'returns the elements in order by score' do
-    @redises.zrevrangebyscore(@key, 4, 3).should == %w[Madison Jefferson]
+    expect(@redises.zrevrangebyscore(@key, 4, 3)).to eq(%w[Madison Jefferson])
   end
 
   it 'returns the scores when :with_scores is specified' do
-    @redises.zrevrangebyscore(@key, 4, 3, :with_scores => true).
-      should == [['Madison', 4.0], ['Jefferson', 3.0]]
+    expect(@redises.zrevrangebyscore(@key, 4, 3, :with_scores => true)).
+      to eq([['Madison', 4.0], ['Jefferson', 3.0]])
   end
 
   it 'returns the scores when :withscores is specified' do
-    @redises.zrevrangebyscore(@key, 4, 3, :withscores => true).
-      should == [['Madison', 4.0], ['Jefferson', 3.0]]
+    expect(@redises.zrevrangebyscore(@key, 4, 3, :withscores => true)).
+      to eq([['Madison', 4.0], ['Jefferson', 3.0]])
   end
 
   it 'treats +inf as positive infinity' do
-    @redises.zrevrangebyscore(@key, '+inf', 3).
-      should == %w[Madison Jefferson]
+    expect(@redises.zrevrangebyscore(@key, '+inf', 3)).
+      to eq(%w[Madison Jefferson])
   end
 
   it 'honors the :limit => [offset count] argument' do
-    @redises.zrevrangebyscore(@key, 100, -100, :limit => [1, 2]).
-      should == %w[Jefferson Adams]
+    expect(@redises.zrevrangebyscore(@key, 100, -100, :limit => [1, 2])).
+      to eq(%w[Jefferson Adams])
   end
 
   it "raises an error if :limit isn't a 2-tuple" do
-    lambda do
+    expect do
       @redises.zrevrangebyscore(@key, 100, -100, :limit => [1, 2, 3])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
 
-    lambda do
+    expect do
       @redises.zrevrangebyscore(@key, 100, -100, :limit => '1, 2')
-    end.should raise_error(RedisMultiplexer::MismatchedResponse)
+    end.to raise_error(RedisMultiplexer::MismatchedResponse)
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zrevrangebyscore_spec.rb
+++ b/spec/commands/zrevrangebyscore_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe '#zrevrangebyscore(key, start, stop [:with_scores => true] [:limit => [offset count]])' do
+RSpec.describe '#zrevrangebyscore(key, start, stop '\
+               '[:with_scores => true] [:limit => [offset count]])' do
   before do
     @key = 'mock-redis-test:zrevrangebyscore'
     @redises.zadd(@key, 1, 'Washington')

--- a/spec/commands/zrevrank_spec.rb
+++ b/spec/commands/zrevrank_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zrevrank(key, member)' do
+RSpec.describe '#zrevrank(key, member)' do
   before do
     @key = 'mock-redis-test:zrevrank'
 
@@ -10,19 +10,19 @@ describe '#zrevrank(key, member)' do
   end
 
   it "returns nil if member wasn't present in the set" do
-    @redises.zrevrank(@key, 'foo').should be_nil
+    expect(@redises.zrevrank(@key, 'foo')).to be_nil
   end
 
   it 'returns the index of the member in the set (ordered by -score)' do
-    @redises.zrevrank(@key, 'one').should == 2
-    @redises.zrevrank(@key, 'two').should == 1
-    @redises.zrevrank(@key, 'three').should == 0
+    expect(@redises.zrevrank(@key, 'one')).to eq(2)
+    expect(@redises.zrevrank(@key, 'two')).to eq(1)
+    expect(@redises.zrevrank(@key, 'three')).to eq(0)
   end
 
   it 'handles integer members correctly' do
     member = 11
     @redises.zadd(@key, 4, member)
-    @redises.zrevrank(@key, member).should == 0
+    expect(@redises.zrevrank(@key, member)).to eq(0)
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zscan_each_spec.rb
+++ b/spec/commands/zscan_each_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zscan_each' do
+RSpec.describe '#zscan_each' do
   subject { MockRedis::Database.new(self) }
 
   let(:key) { 'mock-redis-test:zscan_each' }

--- a/spec/commands/zscan_spec.rb
+++ b/spec/commands/zscan_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zscan' do
+RSpec.describe '#zscan' do
   let(:count) { 10 }
   let(:match) { '*' }
   let(:key) { 'mock-redis-test:zscan' }

--- a/spec/commands/zscore_spec.rb
+++ b/spec/commands/zscore_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
-describe '#zscore(key, member)' do
+RSpec.describe '#zscore(key, member)' do
   before { @key = 'mock-redis-test:zscore' }
 
   it 'returns the score as a string' do
-    @redises.zadd(@key, 0.25, 'foo').should == true
-    @redises.zscore(@key, 'foo').should == 0.25
+    expect(@redises.zadd(@key, 0.25, 'foo')).to eq(true)
+    expect(@redises.zscore(@key, 'foo')).to eq(0.25)
   end
 
   it 'handles integer members correctly' do
     member = 11
-    @redises.zadd(@key, 0.25, member).should == true
-    @redises.zscore(@key, member).should == 0.25
+    expect(@redises.zadd(@key, 0.25, member)).to eq(true)
+    expect(@redises.zscore(@key, member)).to eq(0.25)
   end
 
   it 'returns nil if member is not present in the set' do
-    @redises.zscore(@key, 'foo').should be_nil
+    expect(@redises.zscore(@key, 'foo')).to be_nil
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zunionstore_spec.rb
+++ b/spec/commands/zunionstore_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
+RSpec.describe '#zunionstore(destination, keys, '\
+               '[:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
   before do
     @set1 = 'mock-redis-test:zunionstore1'
     @set2 = 'mock-redis-test:zunionstore2'

--- a/spec/commands/zunionstore_spec.rb
+++ b/spec/commands/zunionstore_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
+RSpec.describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :sum|:min|:max])' do
   before do
     @set1 = 'mock-redis-test:zunionstore1'
     @set2 = 'mock-redis-test:zunionstore2'
@@ -18,27 +18,29 @@ describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
   end
 
   it 'returns the number of elements in the new set' do
-    @redises.zunionstore(@dest, [@set1, @set2, @set3]).should == 3
+    expect(@redises.zunionstore(@dest, [@set1, @set2, @set3])).to eq(3)
   end
 
   it "sums the members' scores by default" do
     @redises.zunionstore(@dest, [@set1, @set2, @set3])
-    @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+    expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
       [['one', 3.0], ['three', 3.0], ['two', 4.0]]
+    )
   end
 
   it 'removes existing elements in destination' do
     @redises.zadd(@dest, 10, 'ten')
 
     @redises.zunionstore(@dest, [@set1])
-    @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+    expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
       [['one', 1.0]]
+    )
   end
 
   it 'raises an error if keys is empty' do
-    lambda do
+    expect do
       @redises.zunionstore(@dest, [])
-    end.should raise_error(Redis::CommandError)
+    end.to raise_error(Redis::CommandError)
   end
 
   context 'when used with a set' do
@@ -51,13 +53,14 @@ describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
     end
 
     it 'returns the number of elements in the new set' do
-      @redises.zunionstore(@dest, [@set3, @set4]).should == 4
+      expect(@redises.zunionstore(@dest, [@set3, @set4])).to eq(4)
     end
 
     it 'sums the scores, substituting 1.0 for set values' do
       @redises.zunionstore(@dest, [@set3, @set4])
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['four', 1.0], ['one', 1.0], ['two', 3.0], ['three', 4.0]]
+      )
     end
   end
 
@@ -68,23 +71,24 @@ describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
       @redises.set(@non_set, 'one')
     end
     it 'raises an error for wrong value type' do
-      lambda do
+      expect do
         @redises.zunionstore(@dest, [@set1, @non_set])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
   context 'the :weights argument' do
     it 'multiplies the scores by the weights while aggregating' do
       @redises.zunionstore(@dest, [@set1, @set2, @set3], :weights => [2, 3, 5])
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['one', 10.0], ['three', 15.0], ['two', 16.0]]
+      )
     end
 
     it 'raises an error if the number of weights != the number of keys' do
-      lambda do
+      expect do
         @redises.zunionstore(@dest, [@set1, @set2, @set3], :weights => [1, 2])
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
@@ -101,37 +105,39 @@ describe '#zunionstore(destination, keys, [:weights => [w,w,], [:aggregate => :s
 
     it 'aggregates scores with min when :aggregate => :min is specified' do
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => :min)
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['bert', 1.0], ['ernie', 2.0]]
+      )
     end
 
     it 'aggregates scores with max when :aggregate => :max is specified' do
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => :max)
-      @redises.zrange(@dest, 0, -1, :with_scores => true).should ==
+      expect(@redises.zrange(@dest, 0, -1, :with_scores => true)).to eq(
         [['bert', 100.0], ['ernie', 200.0]]
+      )
     end
 
     it 'ignores scores for missing members' do
       @redises.zadd(@smalls, 3, 'grover')
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => :min)
-      @redises.zscore(@dest, 'grover').should == 3.0
+      expect(@redises.zscore(@dest, 'grover')).to eq(3.0)
 
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => :max)
-      @redises.zscore(@dest, 'grover').should == 3.0
+      expect(@redises.zscore(@dest, 'grover')).to eq(3.0)
     end
 
     it "allows 'min', 'MIN', etc. as aliases for :min" do
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => 'min')
-      @redises.zscore(@dest, 'bert').should == 1.0
+      expect(@redises.zscore(@dest, 'bert')).to eq(1.0)
 
       @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => 'MIN')
-      @redises.zscore(@dest, 'bert').should == 1.0
+      expect(@redises.zscore(@dest, 'bert')).to eq(1.0)
     end
 
     it 'raises an error for unknown aggregation function' do
-      lambda do
+      expect do
         @redises.zunionstore(@dest, [@bigs, @smalls], :aggregate => :mix)
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 end

--- a/spec/mock_redis_spec.rb
+++ b/spec/mock_redis_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
-describe MockRedis do
+RSpec.describe MockRedis do
   let(:url) { 'redis://127.0.0.1:6379/1' }
 
   describe '.new' do
     subject { MockRedis.new(:url => url) }
 
     it 'correctly parses options' do
-      subject.host.should == '127.0.0.1'
-      subject.port.should == 6379
-      subject.db.should == 1
+      expect(subject.host).to eq('127.0.0.1')
+      expect(subject.port).to eq(6379)
+      expect(subject.db).to eq(1)
     end
 
     its(:id) { should == url }
@@ -22,9 +22,9 @@ describe MockRedis do
     subject { MockRedis.connect(:url => url) }
 
     it 'correctly parses options' do
-      subject.host.should == '127.0.0.1'
-      subject.port.should == 6379
-      subject.db.should == 0
+      expect(subject.host).to eq('127.0.0.1')
+      expect(subject.port).to eq(6379)
+      expect(subject.db).to eq(0)
     end
 
     its(:id) { should == url }
@@ -38,13 +38,13 @@ describe MockRedis do
       it 'defaults to Time' do
         mock_redis = MockRedis.new
 
-        mock_redis.options[:time_class].should == Time
+        expect(mock_redis.options[:time_class]).to eq(Time)
       end
 
       it 'has a configurable Time class' do
         mock_redis = MockRedis.new(options)
 
-        mock_redis.options[:time_class].should == time_stub
+        expect(mock_redis.options[:time_class]).to eq(time_stub)
       end
     end
 
@@ -75,9 +75,9 @@ describe MockRedis do
       subject { MockRedis.new(options) }
 
       it 'Forwards time_at to the time_class' do
-        time_stub.should_receive(:at).with(timestamp).and_return(time_at)
+        expect(time_stub).to receive(:at).with(timestamp).and_return(time_at)
 
-        subject.time_at(timestamp).should == time_at
+        expect(subject.time_at(timestamp)).to eq(time_at)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,13 +44,17 @@ module TypeCheckingHelper
 end
 
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = [:expect, :should]
+  config.expect_with(:rspec) do |expectations|
+    expectations.syntax = :expect
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  config.mock_with :rspec do |c|
-    c.syntax = [:expect, :should]
+  config.mock_with(:rspec) do |mocks|
+    mocks.syntax = :expect
   end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
 
   config.include(TypeCheckingHelper)
 

--- a/spec/support/shared_examples/does_not_cleanup_empty_strings.rb
+++ b/spec/support/shared_examples/does_not_cleanup_empty_strings.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'does not remove empty strings on error' do
+RSpec.shared_examples_for 'does not remove empty strings on error' do
   it 'does not remove empty strings on error' do |example|
     key = 'mock-redis-test:not-a-string'
 
@@ -6,9 +6,9 @@ shared_examples_for 'does not remove empty strings on error' do
     args = args_for_method(method).unshift(key)
 
     @redises.set(key, '')
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(defined?(default_error) ? default_error : RuntimeError)
-    @redises.get(key).should == ''
+    end.to raise_error(defined?(default_error) ? default_error : RuntimeError)
+    expect(@redises.get(key)).to eq('')
   end
 end

--- a/spec/support/shared_examples/only_operates_on_hashes.rb
+++ b/spec/support/shared_examples/only_operates_on_hashes.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a hash-only command' do
+RSpec.shared_examples_for 'a hash-only command' do
   it 'raises an error for non-hash values' do |example|
     key = 'mock-redis-test:hash-only'
 
@@ -6,9 +6,9 @@ shared_examples_for 'a hash-only command' do
     args = args_for_method(method).unshift(key)
 
     @redises.set(key, 1)
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'

--- a/spec/support/shared_examples/only_operates_on_lists.rb
+++ b/spec/support/shared_examples/only_operates_on_lists.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a list-only command' do
+RSpec.shared_examples_for 'a list-only command' do
   it 'raises an error for non-list values' do |example|
     key = 'mock-redis-test:list-only'
 
@@ -6,9 +6,9 @@ shared_examples_for 'a list-only command' do
     args = args_for_method(method).unshift(key)
 
     @redises.set(key, 1)
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(defined?(default_error) ? default_error : RuntimeError)
+    end.to raise_error(defined?(default_error) ? default_error : RuntimeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'

--- a/spec/support/shared_examples/only_operates_on_sets.rb
+++ b/spec/support/shared_examples/only_operates_on_sets.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a set-only command' do
+RSpec.shared_examples_for 'a set-only command' do
   it 'raises an error for non-set values' do |example|
     key = 'mock-redis-test:set-only'
 
@@ -6,9 +6,9 @@ shared_examples_for 'a set-only command' do
     args = args_for_method(method).unshift(key)
 
     @redises.set(key, 1)
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'

--- a/spec/support/shared_examples/only_operates_on_strings.rb
+++ b/spec/support/shared_examples/only_operates_on_strings.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a string-only command' do
+RSpec.shared_examples_for 'a string-only command' do
   it 'raises an error for non-string values' do |example|
     key = 'mock-redis-test:string-only-command'
 
@@ -6,8 +6,8 @@ shared_examples_for 'a string-only command' do
     args = args_for_method(method).unshift(key)
 
     @redises.lpush(key, 1)
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 end

--- a/spec/support/shared_examples/only_operates_on_zsets.rb
+++ b/spec/support/shared_examples/only_operates_on_zsets.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a zset-only command' do
+RSpec.shared_examples_for 'a zset-only command' do
   it 'raises an error for non-zset values' do |example|
     key = 'mock-redis-test:zset-only'
 
@@ -6,25 +6,25 @@ shared_examples_for 'a zset-only command' do
     args = args_for_method(method).unshift(key)
 
     @redises.set(key, 1)
-    lambda do
+    expect do
       @redises.send(method, *args)
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'
 end
 
-shared_examples_for 'arg 1 is a score' do
+RSpec.shared_examples_for 'arg 1 is a score' do
   before { @_arg_index = 1 }
   it_should_behave_like 'arg N is a score'
 end
 
-shared_examples_for 'arg 2 is a score' do
+RSpec.shared_examples_for 'arg 2 is a score' do
   before { @_arg_index = 2 }
   it_should_behave_like 'arg N is a score'
 end
 
-shared_examples_for 'arg N is a score' do
+RSpec.shared_examples_for 'arg N is a score' do
   before do |example|
     key = 'mock-redis-test:zset-only'
 
@@ -34,26 +34,26 @@ shared_examples_for 'arg N is a score' do
 
   it 'is okay with positive ints' do
     @args[@_arg_index] = 1
-    lambda { @redises.send(@method, *@args) }.should_not raise_error
+    expect { @redises.send(@method, *@args) }.not_to raise_error
   end
 
   it 'is okay with negative ints' do
     @args[@_arg_index] = -1
-    lambda { @redises.send(@method, *@args) }.should_not raise_error
+    expect { @redises.send(@method, *@args) }.not_to raise_error
   end
 
   it 'is okay with positive floats' do
     @args[@_arg_index] = 1.5
-    lambda { @redises.send(@method, *@args) }.should_not raise_error
+    expect { @redises.send(@method, *@args) }.not_to raise_error
   end
 
   it 'is okay with negative floats' do
     @args[@_arg_index] = -1.5
-    lambda { @redises.send(@method, *@args) }.should_not raise_error
+    expect { @redises.send(@method, *@args) }.not_to raise_error
   end
 
   it 'rejects non-numbers' do
     @args[@_arg_index] = 'foo'
-    lambda { @redises.send(@method, *@args) }.should raise_error(RuntimeError)
+    expect { @redises.send(@method, *@args) }.to raise_error(RuntimeError)
   end
 end

--- a/spec/support/shared_examples/sorts_enumerables.rb
+++ b/spec/support/shared_examples/sorts_enumerables.rb
@@ -1,56 +1,56 @@
-shared_examples_for 'a sortable' do
+RSpec.shared_examples_for 'a sortable' do
   it 'returns empty array on nil' do
-    @redises.sort(nil).should == []
+    expect(@redises.sort(nil)).to eq([])
   end
 
   context 'ordering' do
     it 'orders ascending by default' do
-      @redises.sort(@key).should == %w[1 2]
+      expect(@redises.sort(@key)).to eq(%w[1 2])
     end
 
     it 'orders by descending when specified' do
-      @redises.sort(@key, :order => 'DESC').should == %w[2 1]
+      expect(@redises.sort(@key, :order => 'DESC')).to eq(%w[2 1])
     end
   end
 
   context 'projections' do
     it 'projects element when :get is "#"' do
-      @redises.sort(@key, :get => '#').should == %w[1 2]
+      expect(@redises.sort(@key, :get => '#')).to eq(%w[1 2])
     end
 
     it 'projects through a key pattern' do
-      @redises.sort(@key, :get => 'mock-redis-test:values_*').should == %w[a b]
+      expect(@redises.sort(@key, :get => 'mock-redis-test:values_*')).to eq(%w[a b])
     end
 
     it 'projects through a key pattern and reflects element' do
-      @redises.sort(@key, :get => ['#', 'mock-redis-test:values_*']).should == [%w[1 a], %w[2 b]]
+      expect(@redises.sort(@key, :get => ['#', 'mock-redis-test:values_*'])).to eq([%w[1 a], %w[2 b]])
     end
 
     it 'projects through a hash key pattern' do
-      @redises.sort(@key, :get => 'mock-redis-test:hash_*->key').should == %w[x y]
+      expect(@redises.sort(@key, :get => 'mock-redis-test:hash_*->key')).to eq(%w[x y])
     end
   end
 
   context 'weights' do
     it 'weights by projecting through a key pattern' do
-      @redises.sort(@key, :by => 'mock-redis-test:weight_*').should == %w[2 1]
+      expect(@redises.sort(@key, :by => 'mock-redis-test:weight_*')).to eq(%w[2 1])
     end
 
     it 'weights by projecting through a key pattern and a specific order' do
-      @redises.sort(@key, :order => 'DESC', :by => 'mock-redis-test:weight_*').should == %w[1 2]
+      expect(@redises.sort(@key, :order => 'DESC', :by => 'mock-redis-test:weight_*')).to eq(%w[1 2])
     end
   end
 
   context 'limit' do
     it 'only returns requested window in the enumerable' do
-      @redises.sort(@key, :limit => [0, 1]).should == ['1']
+      expect(@redises.sort(@key, :limit => [0, 1])).to eq(['1'])
     end
   end
 
   context 'store' do
     it 'stores into another key' do
-      @redises.sort(@key, :store => 'mock-redis-test:some_bucket').should == 2
-      @redises.lrange('mock-redis-test:some_bucket', 0, -1).should == %w[1 2]
+      expect(@redises.sort(@key, :store => 'mock-redis-test:some_bucket')).to eq(2)
+      expect(@redises.lrange('mock-redis-test:some_bucket', 0, -1)).to eq(%w[1 2])
     end
   end
 end

--- a/spec/support/shared_examples/sorts_enumerables.rb
+++ b/spec/support/shared_examples/sorts_enumerables.rb
@@ -23,7 +23,8 @@ RSpec.shared_examples_for 'a sortable' do
     end
 
     it 'projects through a key pattern and reflects element' do
-      expect(@redises.sort(@key, :get => ['#', 'mock-redis-test:values_*'])).to eq([%w[1 a], %w[2 b]])
+      expect(@redises.sort(@key, :get => ['#', 'mock-redis-test:values_*']))
+        .to eq([%w[1 a], %w[2 b]])
     end
 
     it 'projects through a hash key pattern' do
@@ -37,7 +38,8 @@ RSpec.shared_examples_for 'a sortable' do
     end
 
     it 'weights by projecting through a key pattern and a specific order' do
-      expect(@redises.sort(@key, :order => 'DESC', :by => 'mock-redis-test:weight_*')).to eq(%w[1 2])
+      expect(@redises.sort(@key, :order => 'DESC', :by => 'mock-redis-test:weight_*'))
+        .to eq(%w[1 2])
     end
   end
 

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
-describe 'transactions (multi/exec/discard)' do
+RSpec.describe 'transactions (multi/exec/discard)' do
   before(:each) do
     @redises.discard rescue nil
   end
 
   context '#multi' do
     it "responds with 'OK'" do
-      @redises.multi.should == 'OK'
+      expect(@redises.multi).to eq('OK')
     end
 
     it 'does not permit nesting' do
       @redises.multi
-      lambda do
+      expect do
         @redises.multi
-      end.should raise_error(Redis::CommandError, 'ERR MULTI calls can not be nested')
+      end.to raise_error(Redis::CommandError, 'ERR MULTI calls can not be nested')
     end
 
     it 'cleans state of transaction wrapper if exception occurs during transaction' do
-      lambda do
+      expect do
         @redises.mock.multi do |_r|
           raise "i'm a command that fails"
         end
-      end.should raise_error(RuntimeError)
+      end.to raise_error(RuntimeError)
 
       # before the fix this used to raised a #<RuntimeError: ERR MULTI calls can not be nested>
-      lambda do
+      expect do
         @redises.mock.multi do |r|
           # do stuff that succeed
           r.set(nil, 'string')
         end
-      end.should_not raise_error
+      end.not_to raise_error
     end
   end
 
@@ -41,8 +41,8 @@ describe 'transactions (multi/exec/discard)' do
         r.set('test', 1)
         r.incr('counter')
       end
-      @redises.get('counter').should eq '6'
-      @redises.get('test').should eq '1'
+      expect(@redises.get('counter')).to eq '6'
+      expect(@redises.get('test')).to eq '1'
     end
 
     it 'permits nesting via blocks' do
@@ -50,9 +50,9 @@ describe 'transactions (multi/exec/discard)' do
       # nested #multi calls raise NoMethodError because it gets a nil
       # where it's not expecting one.
       @redises.mock.multi do |r|
-        lambda do
+        expect do
           r.multi {}
-        end.should_not raise_error
+        end.not_to raise_error
       end
     end
 
@@ -64,8 +64,8 @@ describe 'transactions (multi/exec/discard)' do
           pr.incr('counter')
         end
       end
-      @redises.get('counter').should eq '6'
-      @redises.get('test').should eq '1'
+      expect(@redises.get('counter')).to eq '6'
+      expect(@redises.get('test')).to eq '1'
     end
 
     it 'allows blocks within multi blocks' do
@@ -79,29 +79,29 @@ describe 'transactions (multi/exec/discard)' do
         r.del('foo', 'fuu')
       end
 
-      result.value.should eq %w[BAR BAZ]
-      @redises.get('foo').should eq nil
-      @redises.get('fuu').should eq nil
+      expect(result.value).to eq %w[BAR BAZ]
+      expect(@redises.get('foo')).to eq nil
+      expect(@redises.get('fuu')).to eq nil
     end
   end
 
   context '#discard' do
     it "responds with 'OK' after #multi" do
       @redises.multi
-      @redises.discard.should eq 'OK'
+      expect(@redises.discard).to eq 'OK'
     end
 
     it "can't be run outside of #multi/#exec" do
-      lambda do
+      expect do
         @redises.discard
-      end.should raise_error(Redis::CommandError)
+      end.to raise_error(Redis::CommandError)
     end
   end
 
   context '#exec' do
     it 'raises an error outside of #multi' do
       lambda do
-        @redises.exec.should raise_error
+        expect(@redises.exec).to raise_error
       end
     end
   end
@@ -114,8 +114,8 @@ describe 'transactions (multi/exec/discard)' do
     end
 
     it "makes commands respond with 'QUEUED'" do
-      @redises.set(@string, 'string').should eq 'QUEUED'
-      @redises.lpush(@list, 'list').should eq 'QUEUED'
+      expect(@redises.set(@string, 'string')).to eq 'QUEUED'
+      expect(@redises.lpush(@list, 'list')).to eq 'QUEUED'
     end
 
     it "gives you the commands' responses when you call #exec" do
@@ -123,7 +123,7 @@ describe 'transactions (multi/exec/discard)' do
       @redises.lpush(@list, 'list')
       @redises.lpush(@list, 'list')
 
-      @redises.exec.should eq ['OK', 1, 2]
+      expect(@redises.exec).to eq ['OK', 1, 2]
     end
 
     it "does not raise exceptions, but rather puts them in #exec's response" do
@@ -132,9 +132,9 @@ describe 'transactions (multi/exec/discard)' do
       @redises.lpush(@list, 'list')
 
       responses = @redises.exec
-      responses[0].should eq 'OK'
-      responses[1].should be_a(Redis::CommandError)
-      responses[2].should eq 1
+      expect(responses[0]).to eq 'OK'
+      expect(responses[1]).to be_a(Redis::CommandError)
+      expect(responses[2]).to eq 1
     end
   end
 
@@ -155,9 +155,9 @@ describe 'transactions (multi/exec/discard)' do
         second_lpush_response = mult.lpush(@list, 'list')
       end
 
-      set_response.value.should eq 'OK'
-      lpush_response.value.should eq 1
-      second_lpush_response.value.should eq 2
+      expect(set_response.value).to eq 'OK'
+      expect(lpush_response.value).to eq 1
+      expect(second_lpush_response.value).to eq 2
     end
   end
 end


### PR DESCRIPTION
Back in RSpec 2.11, a new expectation syntax was introduced. Check out the blog post that outlines the shortcomings of the `should` syntax and how these are resolved with the new `expect` syntax.

https://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/

I propose the RSpec test suite be migrated to this `expect` syntax. Luckily this is quite easy as there is a conversion tool that does all the heavy lifting: [transpec](http://yujinakayama.me/transpec/).

I ran this tool across the test suite and this pull request consists of the changes.