### PR TITLE
CI: add Ruby 3.1 and 3.2 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
             - 6379:6379
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
         redis-version:
           - '6.2'
 
@@ -34,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1.97.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem 'overcommit', '0.53.0'
 # Pin tool versions (which are executed by Overcommit) for Travis builds
 gem 'rubocop', '0.82.0'
 
-gem 'simplecov', '~> 0.21.0'
+gem 'simplecov', '~> 0.22.0'
 gem 'simplecov-lcov', '~> 0.8.0'

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe '#sscan' do
 
   before do
     # The return order of the members is non-deterministic, so we sort them to compare
-    expect_any_instance_of(Redis).to receive(:sscan).and_wrap_original do |m, *args|
-      result = m.call(*args)
+    expect_any_instance_of(Redis).to receive(:sscan).and_wrap_original do |m, *args, **kwargs|
+      result = m.call(*args, **kwargs)
       [result[0], result[1].sort]
     end
-    expect_any_instance_of(MockRedis).to receive(:sscan).and_wrap_original do |m, *args|
-      result = m.call(*args)
+    expect_any_instance_of(MockRedis).to receive(:sscan).and_wrap_original do |m, *args, **kwargs|
+      result = m.call(*args, **kwargs)
       [result[0], result[1].sort]
     end
   end

--- a/spec/support/redis_multiplexer.rb
+++ b/spec/support/redis_multiplexer.rb
@@ -87,7 +87,7 @@ class RedisMultiplexer < BlankSlate
     elsif a.is_a?(Array) && b.is_a?(Array)
       a.collect { |c| masked(c.to_s) }.sort == b.collect { |c| masked(c.to_s) }.sort
     elsif a.is_a?(Exception) && b.is_a?(Exception)
-      a.class == b.class && a.message == b.message
+      a.class == b.class && a.message.split("\n", 2).first == b.message.split("\n", 2).first
     elsif a.is_a?(Float) && b.is_a?(Float)
       delta = [a.abs, b.abs].min / 1_000_000.0
       (a - b).abs < delta


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! To build confidence in compatibility, let's add it to the build matrix, along with Ruby 3.1. 