### PR TITLE
Limit Ruby to 2.6 and above

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: '2.6'
 
 Layout/ArgumentAlignment:
   Enabled: false

--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -130,7 +130,7 @@ class MockRedis
         defaults[:host]     = uri.host
         defaults[:port]     = uri.port if uri.port
         defaults[:password] = uri.password if uri.password
-        defaults[:db]       = uri.path[1..-1].to_i if uri.path
+        defaults[:db]       = uri.path[1..].to_i if uri.path
       end
     end
 

--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -93,7 +93,7 @@ class MockRedis
     def hmset(key, *kvpairs)
       if key.is_a? Array
         err_msg = 'ERR wrong number of arguments for \'hmset\' command'
-        kvpairs = key[1..-1]
+        kvpairs = key[1..]
         key = key[0]
       end
 

--- a/lib/mock_redis/pipelined_wrapper.rb
+++ b/lib/mock_redis/pipelined_wrapper.rb
@@ -41,22 +41,20 @@ class MockRedis
       end
 
       responses = @pipelined_futures.flat_map do |future|
-        begin
-          result = if future.block
-                     send(*future.command, &future.block)
-                   else
-                     send(*future.command)
-                   end
-          future.store_result(result)
+        result = if future.block
+                   send(*future.command, &future.block)
+                 else
+                   send(*future.command)
+                 end
+        future.store_result(result)
 
-          if future.block
-            result
-          else
-            [result]
-          end
-        rescue StandardError => e
-          e
+        if future.block
+          result
+        else
+          [result]
         end
+      rescue StandardError => e
+        e
       end
       @pipelined_futures = []
       responses

--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -171,7 +171,7 @@ class MockRedis
         with_set_at(keys.first, &blk)
       else
         with_set_at(keys.first) do |set|
-          with_sets_at(*(keys[1..-1])) do |*sets|
+          with_sets_at(*(keys[1..])) do |*sets|
             yield(*([set] + sets))
           end
         end

--- a/lib/mock_redis/stream.rb
+++ b/lib/mock_redis/stream.rb
@@ -37,7 +37,7 @@ class MockRedis
         @members = if count == 0
                      Set.new
                    else
-                     @members.to_a[-count..-1].to_set
+                     @members.to_a[-count..].to_set
                    end
         deleted
       else

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -38,7 +38,7 @@ class MockRedis
         type, offset = args.shift(2)
 
         is_signed = type.slice(0) == 'i'
-        type_size = type[1..-1].to_i
+        type_size = type[1..].to_i
 
         if (type_size > 64 && is_signed) || (type_size >= 64 && !is_signed)
           raise Redis::CommandError,
@@ -47,7 +47,7 @@ class MockRedis
         end
 
         if offset.to_s[0] == '#'
-          offset = offset[1..-1].to_i * type_size
+          offset = offset[1..].to_i * type_size
         end
 
         bits = []
@@ -365,7 +365,7 @@ class MockRedis
       old_value = (data[key] || '')
 
       prefix = zero_pad(old_value[0...offset], offset)
-      data[key] = prefix + value + (old_value[(offset + value.length)..-1] || '')
+      data[key] = prefix + value + (old_value[(offset + value.length)..] || '')
       data[key].length
     end
 

--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -57,13 +57,11 @@ class MockRedis
       @multi_block_given = false
 
       responses = @transaction_futures.map do |future|
-        begin
-          result = send(*future.command)
-          future.store_result(result)
-          future.value
-        rescue StandardError => e
-          e
-        end
+        result = send(*future.command)
+        future.store_result(result)
+        future.value
+      rescue StandardError => e
+        e
       end
 
       @transaction_futures = []

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -316,7 +316,7 @@ class MockRedis
         with_zset_at(keys.first, coercible: coercible, &blk)
       else
         with_zset_at(keys.first, coercible: coercible) do |set|
-          with_zsets_at(*(keys[1..-1]), coercible: coercible) do |*sets|
+          with_zsets_at(*(keys[1..]), coercible: coercible) do |*sets|
             yield(*([set] + sets))
           end
         end

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_runtime_dependency 'ruby2_keywords'
 

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#scan' do
     context 'when count is lower than collection size' do
       let(:collection) { Array.new(count * 2) { |i| "mock:key#{i}" } }
       let(:expected_first) { [count.to_s, collection[0...count]] }
-      let(:expected_second) { ['0', collection[count..-1]] }
+      let(:expected_second) { ['0', collection[count..]] }
 
       it 'returns a the next cursor and the collection' do
         expect(subject.scan(0, count: count, match: match)).to eq(expected_first)


### PR DESCRIPTION
### Context

In the [README.md](https://github.com/sds/mock_redis/blob/main/README.md#requirements) document the requirements sections notes Ruby 2.6+.

### Change

- Update the gemspec to enforce the Ruby >= 2.6 constraint.
- Target Ruby 2.6 with Rubocop and apply the suggestions it makes.

   ```
   rubocop --autocorrect-all
   ```