### PR TITLE
Limit Ruby to 2.7 and above

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: '2.7'
 
 Layout/ArgumentAlignment:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for use in tests.
 
 ## Requirements
 
-Ruby 2.6+
+Ruby 2.7+
 
 The current implementation is tested against Redis 6.2. Older versions may work, but can also return different results or not support some commands.
 

--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -1,5 +1,4 @@
 require 'set'
-require 'ruby2_keywords'
 
 require 'mock_redis/assertions'
 require 'mock_redis/database'

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_runtime_dependency 'ruby2_keywords'
 

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_runtime_dependency 'ruby2_keywords'
-
   s.add_development_dependency 'redis', '~> 4.5.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
### Context

Ruby 2.6 reached its end of life in April 2022. It is no longer supported.

### Change

- Update the gemspec to enforce a Ruby >= 2.7 constraint.
- Remove the runtime dependency on the `ruby2_keywords` gem. The functionality provided by this gem comes out-of-the-box with Ruby since version 2.7.
- Remove Ruby 2.6 from the CI test matrix.
- Configure Rubocop to target Ruby 2.7.