### PR TITLE
Add rake as a development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 require 'bundler'
+require 'rubocop/rake_task'
+require 'rspec/core/rake_task'
+
 Bundler::GemHelper.install_tasks
+RuboCop::RakeTask.new
+RSpec::Core::RakeTask.new

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
+  s.add_development_dependency 'rake', '~> 13'
   s.add_development_dependency 'redis', '~> 4.5.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
Add rake as a development dependency and configure RSpec and Rubocop tasks. This provides developers with a familiar and convenient interface for running common tasks.

```
❯ rake -AT
rake build                                # Build mock_redis-0.36.0.gem into the pkg directory
rake build:checksum                       # Generate SHA512 checksum if mock_redis-0.36.0.gem into the checksums directory
rake install                              # Build and install mock_redis-0.36.0.gem into system gems
rake install:local                        # Build and install mock_redis-0.36.0.gem into system gems without network access
rake release[remote]                      # Create tag v0.36.0 and build and push mock_redis-0.36.0.gem to rubygems.org
rake release:guard_clean                  #
rake release:rubygem_push                 #
rake release:source_control_push[remote]  #
rake rubocop                              # Run RuboCop
rake rubocop:auto_correct                 #
rake rubocop:autocorrect                  # Autocorrect RuboCop offenses (only when it's safe)
rake rubocop:autocorrect_all              # Autocorrect RuboCop offenses (safe and unsafe)
rake spec                                 # Run RSpec code examples
```