### PR TITLE
Reduce gem contents

### DIFF
--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -16,9 +16,11 @@ Gem::Specification.new do |s|
    normal Redis object. It supports all the usual Redis operations.
   MSG
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- spec/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |file|
+      file.start_with?('lib') || file.end_with?('.md')
+    end
+  end
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.7'


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from **72K** to **30K!**

<details><summary>contents diff</summary>

```diff
< .github/workflows/lint.yml
< .github/workflows/tests.yml
< .gitignore
< .mailmap
< .overcommit.yml
< .rspec
< .rubocop.yml
< .rubocop_todo.yml
< .simplecov
  CHANGELOG.md
< Gemfile
  LICENSE.md
  README.md
< Rakefile
  lib/mock_redis.rb
  lib/mock_redis/assertions.rb
  lib/mock_redis/connection_method.rb
  lib/mock_redis/database.rb
  lib/mock_redis/exceptions.rb
  lib/mock_redis/expire_wrapper.rb
  lib/mock_redis/future.rb
  lib/mock_redis/geospatial_methods.rb
  lib/mock_redis/hash_methods.rb
  lib/mock_redis/indifferent_hash.rb
  lib/mock_redis/info_method.rb
  lib/mock_redis/list_methods.rb
  lib/mock_redis/multi_db_wrapper.rb
  lib/mock_redis/pipelined_wrapper.rb
  lib/mock_redis/set_methods.rb
  lib/mock_redis/sort_method.rb
  lib/mock_redis/stream.rb
  lib/mock_redis/stream/id.rb
  lib/mock_redis/stream_methods.rb
  lib/mock_redis/string_methods.rb
  lib/mock_redis/transaction_wrapper.rb
  lib/mock_redis/undef_redis_methods.rb
  lib/mock_redis/utility_methods.rb
  lib/mock_redis/version.rb
  lib/mock_redis/zset.rb
  lib/mock_redis/zset_methods.rb
< mock_redis.gemspec
< spec/client_spec.rb
< spec/cloning_spec.rb
< spec/commands/append_spec.rb
< spec/commands/auth_spec.rb
< spec/commands/bgrewriteaof_spec.rb
< spec/commands/bgsave_spec.rb
< spec/commands/bitcount_spec.rb
< spec/commands/bitfield_spec.rb
< spec/commands/blmove_spec.rb
< spec/commands/blpop_spec.rb
< spec/commands/brpop_spec.rb
< spec/commands/brpoplpush_spec.rb
< spec/commands/connected_spec.rb
< spec/commands/connection_spec.rb
< spec/commands/dbsize_spec.rb
< spec/commands/decr_spec.rb
< spec/commands/decrby_spec.rb
< spec/commands/del_spec.rb
< spec/commands/disconnect_spec.rb
< spec/commands/dump_spec.rb
< spec/commands/echo_spec.rb
< spec/commands/eval_spec.rb
< spec/commands/evalsha_spec.rb
< spec/commands/exists_spec.rb
< spec/commands/expire_spec.rb
< spec/commands/expireat_spec.rb
< spec/commands/flushall_spec.rb
< spec/commands/flushdb_spec.rb
< spec/commands/future_spec.rb
< spec/commands/geoadd_spec.rb
< spec/commands/geodist_spec.rb
< spec/commands/geohash_spec.rb
< spec/commands/geopos_spec.rb
< spec/commands/get_spec.rb
< spec/commands/getbit_spec.rb
< spec/commands/getdel.rb
< spec/commands/getrange_spec.rb
< spec/commands/getset_spec.rb
< spec/commands/hdel_spec.rb
< spec/commands/hexists_spec.rb
< spec/commands/hget_spec.rb
< spec/commands/hgetall_spec.rb
< spec/commands/hincrby_spec.rb
< spec/commands/hincrbyfloat_spec.rb
< spec/commands/hkeys_spec.rb
< spec/commands/hlen_spec.rb
< spec/commands/hmget_spec.rb
< spec/commands/hmset_spec.rb
< spec/commands/hscan_each_spec.rb
< spec/commands/hscan_spec.rb
< spec/commands/hset_spec.rb
< spec/commands/hsetnx_spec.rb
< spec/commands/hvals_spec.rb
< spec/commands/incr_spec.rb
< spec/commands/incrby_spec.rb
< spec/commands/incrbyfloat_spec.rb
< spec/commands/info_spec.rb
< spec/commands/keys_spec.rb
< spec/commands/lastsave_spec.rb
< spec/commands/lindex_spec.rb
< spec/commands/linsert_spec.rb
< spec/commands/llen_spec.rb
< spec/commands/lmove_spec.rb
< spec/commands/lpop_spec.rb
< spec/commands/lpush_spec.rb
< spec/commands/lpushx_spec.rb
< spec/commands/lrange_spec.rb
< spec/commands/lrem_spec.rb
< spec/commands/lset_spec.rb
< spec/commands/ltrim_spec.rb
< spec/commands/mapped_hmget_spec.rb
< spec/commands/mapped_hmset_spec.rb
< spec/commands/mapped_mget_spec.rb
< spec/commands/mapped_mset_spec.rb
< spec/commands/mapped_msetnx_spec.rb
< spec/commands/mget_spec.rb
< spec/commands/move_spec.rb
< spec/commands/mset_spec.rb
< spec/commands/msetnx_spec.rb
< spec/commands/persist_spec.rb
< spec/commands/pexpire_spec.rb
< spec/commands/pexpireat_spec.rb
< spec/commands/ping_spec.rb
< spec/commands/pipelined_spec.rb
< spec/commands/psetex_spec.rb
< spec/commands/pttl_spec.rb
< spec/commands/quit_spec.rb
< spec/commands/randomkey_spec.rb
< spec/commands/rename_spec.rb
< spec/commands/renamenx_spec.rb
< spec/commands/restore_spec.rb
< spec/commands/rpop_spec.rb
< spec/commands/rpoplpush_spec.rb
< spec/commands/rpush_spec.rb
< spec/commands/rpushx_spec.rb
< spec/commands/sadd_spec.rb
< spec/commands/save_spec.rb
< spec/commands/scan_each_spec.rb
< spec/commands/scan_spec.rb
< spec/commands/scard_spec.rb
< spec/commands/script_spec.rb
< spec/commands/sdiff_spec.rb
< spec/commands/sdiffstore_spec.rb
< spec/commands/select_spec.rb
< spec/commands/set_spec.rb
< spec/commands/setbit_spec.rb
< spec/commands/setex_spec.rb
< spec/commands/setnx_spec.rb
< spec/commands/setrange_spec.rb
< spec/commands/sinter_spec.rb
< spec/commands/sinterstore_spec.rb
< spec/commands/sismember_spec.rb
< spec/commands/smembers_spec.rb
< spec/commands/smismember_spec.rb
< spec/commands/smove_spec.rb
< spec/commands/sort_list_spec.rb
< spec/commands/sort_set_spec.rb
< spec/commands/sort_zset_spec.rb
< spec/commands/spop_spec.rb
< spec/commands/srandmember_spec.rb
< spec/commands/srem_spec.rb
< spec/commands/sscan_each_spec.rb
< spec/commands/sscan_spec.rb
< spec/commands/strlen_spec.rb
< spec/commands/sunion_spec.rb
< spec/commands/sunionstore_spec.rb
< spec/commands/ttl_spec.rb
< spec/commands/type_spec.rb
< spec/commands/unwatch_spec.rb
< spec/commands/watch_spec.rb
< spec/commands/xadd_spec.rb
< spec/commands/xlen_spec.rb
< spec/commands/xrange_spec.rb
< spec/commands/xread_spec.rb
< spec/commands/xrevrange_spec.rb
< spec/commands/xtrim_spec.rb
< spec/commands/zadd_spec.rb
< spec/commands/zcard_spec.rb
< spec/commands/zcount_spec.rb
< spec/commands/zincrby_spec.rb
< spec/commands/zinterstore_spec.rb
< spec/commands/zpopmax_spec.rb
< spec/commands/zpopmin_spec.rb
< spec/commands/zrange_spec.rb
< spec/commands/zrangebyscore_spec.rb
< spec/commands/zrank_spec.rb
< spec/commands/zrem_spec.rb
< spec/commands/zremrangebyrank_spec.rb
< spec/commands/zremrangebyscore_spec.rb
< spec/commands/zrevrange_spec.rb
< spec/commands/zrevrangebyscore_spec.rb
< spec/commands/zrevrank_spec.rb
< spec/commands/zscan_each_spec.rb
< spec/commands/zscan_spec.rb
< spec/commands/zscore_spec.rb
< spec/commands/zunionstore_spec.rb
< spec/mock_redis_spec.rb
< spec/spec_helper.rb
< spec/support/redis_multiplexer.rb
< spec/support/shared_examples/does_not_cleanup_empty_strings.rb
< spec/support/shared_examples/only_operates_on_hashes.rb
< spec/support/shared_examples/only_operates_on_lists.rb
< spec/support/shared_examples/only_operates_on_sets.rb
< spec/support/shared_examples/only_operates_on_strings.rb
< spec/support/shared_examples/only_operates_on_zsets.rb
< spec/support/shared_examples/sorts_enumerables.rb
< spec/transactions_spec.rb
```

</details>