### PR TITLE
Support #scan with type option

### DIFF
--- a/lib/mock_redis/utility_methods.rb
+++ b/lib/mock_redis/utility_methods.rb
@@ -28,6 +28,7 @@ class MockRedis
       cursor = cursor.to_i
       match = opts[:match] || '*'
       key = opts[:key] || lambda { |x| x }
+      type_opt = opts[:type]
       filtered_values = []
 
       limit = cursor + count
@@ -35,7 +36,8 @@ class MockRedis
 
       unless values[cursor...limit].nil?
         filtered_values = values[cursor...limit].select do |val|
-          redis_pattern_to_ruby_regex(match).match(key.call(val))
+          redis_pattern_to_ruby_regex(match).match(key.call(val)) &&
+            (type_opt.nil? || type(val) == type_opt)
         end
       end
 

--- a/lib/mock_redis/zset.rb
+++ b/lib/mock_redis/zset.rb
@@ -10,9 +10,11 @@ class MockRedis
 
     def_delegators :members, :empty?, :include?, :size
 
-    def initialize
+    def initialize(enum = nil)
       @members = Set.new
-      @scores  = {}
+      @members.merge(enum) if enum
+
+      @scores = {}
     end
 
     def initialize_copy(source)

--- a/spec/commands/scan_each_spec.rb
+++ b/spec/commands/scan_each_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe '#scan_each' do
   let(:match) { '*' }
 
   before do
-    allow(subject).to receive_message_chain(:data, :keys).and_return(collection)
+    allow(subject).to receive(:data).and_return(data)
   end
 
   context 'when no keys are found' do
-    let(:collection) { [] }
+    let(:data) { {} }
 
     it 'does not iterate over any elements' do
       expect(subject.scan_each.to_a).to be_empty
@@ -19,20 +19,37 @@ RSpec.describe '#scan_each' do
 
   context 'when keys are found' do
     context 'when no match filter is supplied' do
-      let(:collection) { Array.new(20) { |i| "mock:key#{i}" } }
+      let(:data) { Array.new(20) { |i| "mock:key#{i}" }.to_h { |e| [e, nil] } }
 
       it 'iterates over each item in the collection' do
-        expect(subject.scan_each.to_a).to match_array(collection)
+        expect(subject.scan_each.to_a).to match_array(data.keys)
       end
     end
 
     context 'when giving a custom match filter' do
       let(:match) { 'mock:key*' }
-      let(:collection) { %w[mock:key mock:key2 mock:otherkey] }
+      let(:data) { ['mock:key', 'mock:key2', 'mock:otherkey'].to_h { |e| [e, nil] } }
       let(:expected) { %w[mock:key mock:key2] }
 
       it 'iterates over each item in the filtered collection' do
         expect(subject.scan_each(match: match).to_a).to match_array(expected)
+      end
+    end
+
+    context 'when giving a custom match and type filter' do
+      let(:data) do
+        { 'mock:stringkey' => 'mockvalue',
+          'mock:listkey' => ['mockvalue1'],
+          'mock:hashkey' => { 'mocksubkey' => 'mockvalue' },
+          'mock:setkey' => Set.new(['mockvalue']),
+          'mock:zsetkey' => MockRedis::Zset.new(['mockvalue']) }
+      end
+      let(:match) { 'mock:*' }
+      let(:type) { 'string' }
+      let(:expected) { %w[mock:stringkey] }
+
+      it 'iterates over each item in the filtered collection' do
+        expect(subject.scan_each(match: match, type: type)).to match_array(expected)
       end
     end
   end

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe '#scan' do
   let(:match) { '*' }
 
   before do
-    allow(subject).to receive_message_chain(:data, :keys).and_return(collection)
+    allow(subject).to receive(:data).and_return(data)
   end
 
   context 'when no keys are found' do
-    let(:collection) { [] }
+    let(:data) { {} }
 
     it 'returns a 0 cursor and an empty collection' do
       expect(subject.scan(0, count: count, match: match)).to eq(['0', []])
@@ -20,9 +20,9 @@ RSpec.describe '#scan' do
 
   context 'when keys are found' do
     context 'when count is lower than collection size' do
-      let(:collection) { Array.new(count * 2) { |i| "mock:key#{i}" } }
-      let(:expected_first) { [count.to_s, collection[0...count]] }
-      let(:expected_second) { ['0', collection[count..]] }
+      let(:data) { Array.new(count * 2) { |i| "mock:key#{i}" }.to_h { |e| [e, nil] } }
+      let(:expected_first) { [count.to_s, data.keys[0...count]] }
+      let(:expected_second) { ['0', data.keys[count..]] }
 
       it 'returns a the next cursor and the collection' do
         expect(subject.scan(0, count: count, match: match)).to eq(expected_first)
@@ -34,8 +34,8 @@ RSpec.describe '#scan' do
     end
 
     context 'when count is greater or equal than collection size' do
-      let(:collection) { Array.new(count) { |i| "mock:key#{i}" } }
-      let(:expected) { ['0', collection] }
+      let(:data) { Array.new(count) { |i| "mock:key#{i}" }.to_h { |e| [e, nil] } }
+      let(:expected) { ['0', data.keys] }
 
       it 'returns a 0 cursor and the collection' do
         expect(subject.scan(0, count: count, match: match)).to eq(expected)
@@ -43,7 +43,7 @@ RSpec.describe '#scan' do
     end
 
     context 'when cursor is greater than collection size' do
-      let(:collection) { Array.new(count) { |i| "mock:key#{i}" } }
+      let(:data) { Array.new(count) { |i| "mock:key#{i}" }.to_h { |e| [e, nil] } }
       let(:expected) { ['0', []] }
 
       it 'returns a 0 cursor and empty collection' do
@@ -53,11 +53,28 @@ RSpec.describe '#scan' do
 
     context 'when giving a custom match filter' do
       let(:match) { 'mock:key*' }
-      let(:collection) { %w[mock:key mock:key2 mock:otherkey] }
+      let(:data) { ['mock:key', 'mock:key2', 'mock:otherkey'].to_h { |e| [e, nil] } }
       let(:expected) { ['0', %w[mock:key mock:key2]] }
 
       it 'returns a 0 cursor and the filtered collection' do
         expect(subject.scan(0, count: count, match: match)).to eq(expected)
+      end
+    end
+
+    context 'when giving a custom match and type filter' do
+      let(:data) do
+        { 'mock:stringkey' => 'mockvalue',
+          'mock:listkey' => ['mockvalue1'],
+          'mock:hashkey' => { 'mocksubkey' => 'mockvalue' },
+          'mock:setkey' => Set.new(['mockvalue']),
+          'mock:zsetkey' => MockRedis::Zset.new(['mockvalue']) }
+      end
+      let(:match) { 'mock:*' }
+      let(:type) { 'string' }
+      let(:expected) { ['0', %w[mock:stringkey]] }
+
+      it 'returns a 0 cursor and the filtered collection' do
+        expect(subject.scan(0, count: count, match: match, type: type)).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
👋 This PR adds `type` option support to `scan` and `scan_each`. See the Redis docs [here](https://redis.io/commands/scan/#the-type-option).

In order to make testing easier, I also added an optional enumerator parameter to the intializer of `Zset`.
I also altered the `scan` and `scan_each` specs to define the `data` hash instead of `collection` key array, since the `Database#type` method requires inspecting the data hash's values.