### PR TITLE
Add support for scanning on keys containing hash tags

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -336,7 +336,7 @@ class MockRedis
     def redis_pattern_to_ruby_regex(pattern)
       Regexp.new(
         "^#{pattern}$".
-        gsub(/([+|()])/, '\\\\\1').
+        gsub(/([+|(){}])/, '\\\\\1').
         gsub(/(?<!\\)\?/, '\\1.').
         gsub(/([^\\])\*/, '\\1.*')
       )

--- a/spec/commands/scan_each_spec.rb
+++ b/spec/commands/scan_each_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe '#scan_each' do
       end
     end
 
+    context 'when giving a custom match filter with a hash tag' do
+      let(:match) { 'mock:key:{1}:*' }
+      let(:data) { ['mock:key:{1}:1', 'mock:key:{1}:2', 'mock:key:{2}:1'].to_h { |e| [e, nil] } }
+      let(:expected) { %w[mock:key:{1}:1 mock:key:{1}:2] }
+
+      it 'returns a 0 cursor and the filtered collection' do
+        expect(subject.scan_each(match: match)).to match_array(expected)
+      end
+    end
+
+
     context 'when giving a custom match and type filter' do
       let(:data) do
         { 'mock:stringkey' => 'mockvalue',

--- a/spec/commands/scan_each_spec.rb
+++ b/spec/commands/scan_each_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe '#scan_each' do
       end
     end
 
-
     context 'when giving a custom match and type filter' do
       let(:data) do
         { 'mock:stringkey' => 'mockvalue',

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe '#scan' do
       end
     end
 
+    context 'when giving a custom match filter with a hash tag' do
+      let(:match) { 'mock:key:{1}:*' }
+      let(:data) { ['mock:key:{1}:1', 'mock:key:{1}:2', 'mock:key:{2}:1'].to_h { |e| [e, nil] } }
+      let(:expected) { ['0', %w[mock:key:{1}:1 mock:key:{1}:2]] }
+
+      it 'returns a 0 cursor and the filtered collection' do
+        expect(subject.scan(0, count: count, match: match)).to eq(expected)
+      end
+    end
+
     context 'when giving a custom match and type filter' do
       let(:data) do
         { 'mock:stringkey' => 'mockvalue',


### PR DESCRIPTION
This PR adds support for scanning on keys containing hash tags. This is mainly relevant when working with Redis in cluster mode. If `mock_redis` is not supposed to support Cluster mode, I understand if you want to close this PR.

[Hash tags](https://redis.io/docs/management/scaling/) are parts of a key surrounded by `{}`. This is used in cluster mode to ensure a set of keys is stored on the same node. MockRedis does not support this and scanning on a key containing a hash tag does not work because the resulting regex pattern created by `redis_pattern_to_ruby_regex` does not escape curly braces.

The added commit is a suggestion on how support can be added. If there is a better way, feel free to edit directly or notify me and I will make the required change.