### PR TITLE
Cut version 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MockRedis Changelog
 
+### 0.37.0
+
+* Require Ruby 2.7 or newer, since Ruby 2.6 and older are EOL
+* Remove unnecessary files from gem contents
+* Add support for popping multiple items with `lpop`
+* Add support for `scan` with type option
+* Add support for `sadd?`
+* Add support for scanning on keys containing hash tags (`{...}`)
+
 ### 0.36.0
 
 * Add support for `smismember`

--- a/lib/mock_redis/version.rb
+++ b/lib/mock_redis/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 class MockRedis
-  VERSION = '0.36.0'
+  VERSION = '0.37.0'
 end


### PR DESCRIPTION
* Require Ruby 2.7 or newer, since Ruby 2.6 and older are EOL
* Remove unnecessary files from gem contents
* Add support for popping multiple items with `lpop`
* Add support for `scan` with type option
* Add support for `sadd?`
* Add support for scanning on keys containing hash tags (`{...}`)
