### PR TITLE
feat(set_exat_pxat): Add EXAT and PXAT arguments to the SET redis command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MockRedis Changelog
 
+### 0.38.0
+
+* Add support for `EXAT` AND `PXAT` arguments to `SET` command
+
 ### 0.37.0
 
 * Require Ruby 2.7 or newer, since Ruby 2.6 and older are EOL

--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -210,9 +210,10 @@ class MockRedis
       msetnx(*hash.to_a.flatten)
     end
 
-    # Parameer list required to ensure the ArgumentError is returned correctly
+    # Parameter list required to ensure the ArgumentError is returned correctly
     # rubocop:disable Metrics/ParameterLists
-    def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
+    def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil,
+      get: nil)
       key = key.to_s
       retval = self.get(key) if get
 
@@ -246,6 +247,20 @@ class MockRedis
           raise Redis::CommandError, 'ERR invalid expire time in set'
         end
         pexpire(key, px)
+      end
+
+      if exat
+        if exat == 0
+          raise Redis::CommandError, 'ERR invalid expire time in set'
+        end
+        expireat(key, exat)
+      end
+
+      if pxat
+        if pxat == 0
+          raise Redis::CommandError, 'ERR invalid expire time in set'
+        end
+        pexpireat(key, pxat)
       end
 
       if get

--- a/lib/mock_redis/version.rb
+++ b/lib/mock_redis/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 class MockRedis
-  VERSION = '0.37.0'
+  VERSION = '0.38.0'
 end


### PR DESCRIPTION
Related with this issue https://github.com/sds/mock_redis/issues/279 

* Documentation for the feature here: https://redis.io/commands/set/
* Added tests for SET ... EXAT and PXAT on a valid and invalid key

Hope you find it useful 😄 