### PR TITLE
Implement `call` method in `pipelined` block

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -49,10 +49,6 @@ class MockRedis
   end
   alias location id
 
-  def call(command, &_block)
-    send(*command)
-  end
-
   def host
     options[:host]
   end

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -43,6 +43,10 @@ class MockRedis
 
     # Redis commands go below this line and above 'private'
 
+    def call(command, &_block)
+      public_send(*command)
+    end
+
     def auth(_)
       'OK'
     end

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -111,4 +111,26 @@ RSpec.describe '#pipelined' do
       expect(results).to eq([value1, value2])
     end
   end
+
+  context 'with `call` method' do
+    let(:key1)   { 'hello' }
+    let(:key2)   { 'world' }
+    let(:value1) { 'foo' }
+    let(:value2) { 'bar' }
+
+    before do
+      @redises.set key1, value1
+      @redises.set key2, value2
+    end
+
+    it 'returns results of pipelined operations' do
+      results = @redises.pipelined do |redis|
+        redis.call(['get', key1])
+        redis.call(['set', key2, 'foobar'])
+        redis.call(['get', key2])
+      end
+
+      expect(results).to eq([value1, 'OK', 'foobar'])
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/sds/mock_redis/issues/278

Seems like everything is working; however, I'm not sure if moving `#call` from `MockRedis` to `MockRedis::Database` has some side-effects -- is there a reason `call` was separated from other commands?

I also changed `send` to `public_send` in `call` implementation (seems to be OK, I'm not sure if there are any edge cases when calling private is a usecase).

Also, I think we should allow mix-cased variants of Redis methods (`RedisMock.new.call(["GET", 123])` does not work right now, but redis commands are case insensitive).

Usage example:

```ruby
redis = MockRedis.new

redis.pipelined do |pipeline|
  pipeline.call(["get", "foo"])
  pipeline.call(["get", "bar"])
end
```
