### PR TITLE
Real Redis adds an Array as a stringified member

### DIFF
--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -8,7 +8,7 @@ class MockRedis
 
     def sadd(key, members)
       members_class = members.class
-      members = [members].flatten.map(&:to_s)
+      members = Array(members).map(&:to_s)
       assert_has_args(members, 'sadd')
 
       with_set_at(key) do |s|

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe '#sadd(key, member)' do
       expect(@redises.smembers(@key)).to eq(%w[1 2 3])
     end
 
+    it 'adds an Array as a stringified member' do
+      @redises.sadd(@key, [[1], 2, 3])
+      expect(@redises.smembers(@key)).to eq(%w[[1] 2 3])
+    end
+
     it 'raises an error if an empty array is given' do
       expect do
         @redises.sadd(@key, [])


### PR DESCRIPTION
We were flattening the wrapped array here to get rid of any nesting of arrays we might have accidentally done by wrapping with an Array literal (`[]`). Instead, `Kernel#Array` will leave an existing Array alone, and wrap any single object in an Array. This is consistent with real Redis' behavior.