### PR TITLE
Make `call` method command name case-insensitive

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -44,7 +44,7 @@ class MockRedis
     # Redis commands go below this line and above 'private'
 
     def call(command, &_block)
-      public_send(*command)
+      public_send(command[0].downcase, *command[1..])
     end
 
     def auth(_)

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -132,5 +132,15 @@ RSpec.describe '#pipelined' do
 
       expect(results).to eq([value1, 'OK', 'foobar'])
     end
+
+    it 'works correctly with mixed-case commands' do
+      results = @redises.pipelined do |redis|
+        redis.call(['Get', key1])
+        redis.call(['SET', key2, 'foobar'])
+        redis.call(['gET', key2])
+      end
+
+      expect(results).to eq([value1, 'OK', 'foobar'])
+    end
   end
 end


### PR DESCRIPTION
Redis commands are case-insensitive.

`redis-rb` behavior:

```
[1] redis_connection.call(["sET", "foo", 1])
"OK"
[2] redis_connection.call(["GET", "foo"])
"1"
```
