### PR TITLE
Add support for `expire`-related command options `nx`, `xx`, `lt` and `gt`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           - '3.2'
         redis-version:
           - '6.2'
+          - '7.0'
 
     services:
       redis:
@@ -41,7 +42,7 @@ jobs:
           bundler-cache: true
 
       - name: Run tests
-        run: bundle exec rspec
+        run: bundle exec rspec --tag redis:${{ matrix.redis-version }}
 
       - name: Code coverage reporting
         uses: coverallsapp/github-action@master

--- a/spec/commands/expireat_spec.rb
+++ b/spec/commands/expireat_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe '#expireat(key, timestamp)' do
     end.to raise_error(Redis::CommandError)
   end
 
+  it 'works with options', redis: '7.0' do
+    expect(@redises.expire(@key, Time.now.to_i + 20)).to eq(true)
+    expect(@redises.expire(@key, Time.now.to_i + 10, lt: true)).to eq(true)
+    expect(@redises.expire(@key, Time.now.to_i + 15, lt: true)).to eq(false)
+    expect(@redises.expire(@key, Time.now.to_i + 20, gt: true)).to eq(true)
+    expect(@redises.expire(@key, Time.now.to_i + 15, gt: true)).to eq(false)
+    expect(@redises.expire(@key, Time.now.to_i + 10, xx: true)).to eq(true)
+    expect(@redises.expire(@key, Time.now.to_i + 10, nx: true)).to eq(false)
+    expect(@redises.persist(@key)).to eq(true)
+    expect(@redises.expire(@key, Time.now.to_i + 10, xx: true)).to eq(false)
+    expect(@redises.expire(@key, Time.now.to_i + 10, nx: true)).to eq(true)
+  end
+
   context '[mock only]' do
     # These are mock-only since we can't actually manipulate time in
     # the real Redis.
@@ -37,6 +50,8 @@ RSpec.describe '#expireat(key, timestamp)' do
       @now = Time.now
       allow(Time).to receive(:now).and_return(@now)
     end
+
+    it_should_behave_like 'raises on invalid expire command options', :expireat
 
     it 'removes keys after enough time has passed' do
       @mock.expireat(@key, @now.to_i + 5)

--- a/spec/commands/pexpire_spec.rb
+++ b/spec/commands/pexpire_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe '#pexpire(key, ms)' do
     end.to raise_error(Redis::CommandError)
   end
 
+  it 'works with options', redis: '7.0' do
+    expect(@redises.expire(@key, 20)).to eq(true)
+    expect(@redises.expire(@key, 10, lt: true)).to eq(true)
+    expect(@redises.expire(@key, 15, lt: true)).to eq(false)
+    expect(@redises.expire(@key, 20, gt: true)).to eq(true)
+    expect(@redises.expire(@key, 15, gt: true)).to eq(false)
+    expect(@redises.expire(@key, 10, xx: true)).to eq(true)
+    expect(@redises.expire(@key, 10, nx: true)).to eq(false)
+    expect(@redises.persist(@key)).to eq(true)
+    expect(@redises.expire(@key, 10, xx: true)).to eq(false)
+    expect(@redises.expire(@key, 10, nx: true)).to eq(true)
+  end
+
   it 'stringifies key' do
     expect(@redises.pexpire(@key.to_sym, 9)).to eq(true)
   end
@@ -41,6 +54,8 @@ RSpec.describe '#pexpire(key, ms)' do
       @now = Time.now.round
       allow(Time).to receive(:now).and_return(@now)
     end
+
+    it_should_behave_like 'raises on invalid expire command options', :pexpire
 
     it 'removes keys after enough time has passed' do
       @mock.pexpire(@key, 5)

--- a/spec/commands/pexpireat_spec.rb
+++ b/spec/commands/pexpireat_spec.rb
@@ -6,17 +6,21 @@ RSpec.describe '#pexpireat(key, timestamp_ms)' do
     @redises.set(@key, 'spork')
   end
 
+  def now_ms
+    (Time.now.to_f * 1000).to_i
+  end
+
   it 'returns true for a key that exists' do
-    expect(@redises.pexpireat(@key, (Time.now.to_f * 1000).to_i + 1)).to eq(true)
+    expect(@redises.pexpireat(@key, now_ms + 1)).to eq(true)
   end
 
   it 'returns false for a key that does not exist' do
     expect(@redises.pexpireat('mock-redis-test:nonesuch',
-                       (Time.now.to_f * 1000).to_i + 1)).to eq(false)
+                       now_ms + 1)).to eq(false)
   end
 
   it 'removes a key immediately when timestamp is now' do
-    @redises.pexpireat(@key, (Time.now.to_f * 1000).to_i)
+    @redises.pexpireat(@key, now_ms)
     expect(@redises.get(@key)).to be_nil
   end
 
@@ -24,6 +28,19 @@ RSpec.describe '#pexpireat(key, timestamp_ms)' do
     expect do
       @redises.pexpireat(@key, Time.now) # oops, forgot .to_i
     end.to raise_error(Redis::CommandError)
+  end
+
+  it 'works with options', redis: '7.0' do
+    expect(@redises.expire(@key, now_ms + 20)).to eq(true)
+    expect(@redises.expire(@key, now_ms + 10, lt: true)).to eq(true)
+    expect(@redises.expire(@key, now_ms + 15, lt: true)).to eq(false)
+    expect(@redises.expire(@key, now_ms + 20, gt: true)).to eq(true)
+    expect(@redises.expire(@key, now_ms + 15, gt: true)).to eq(false)
+    expect(@redises.expire(@key, now_ms + 10, xx: true)).to eq(true)
+    expect(@redises.expire(@key, now_ms + 10, nx: true)).to eq(false)
+    expect(@redises.persist(@key)).to eq(true)
+    expect(@redises.expire(@key, now_ms + 10, xx: true)).to eq(false)
+    expect(@redises.expire(@key, now_ms + 10, nx: true)).to eq(true)
   end
 
   context '[mock only]' do
@@ -38,6 +55,8 @@ RSpec.describe '#pexpireat(key, timestamp_ms)' do
       @now = Time.now
       allow(Time).to receive(:now).and_return(@now)
     end
+
+    it_should_behave_like 'raises on invalid expire command options', :pexpireat
 
     it 'removes keys after enough time has passed' do
       @mock.pexpireat(@key, (@now.to_f * 1000).to_i + 5)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,4 +75,9 @@ RSpec.configure do |config|
     end
     @redises._gsub_clear
   end
+
+  # By default, all the specs are considered to be compatible with redis 6,
+  # specs for redis 7 should be marked with `redis: 7.0` tag.
+  config.run_all_when_everything_filtered = true
+  config.filter_run_excluding redis: 7.0
 end

--- a/spec/support/shared_examples/raises_on_invalid_expire_command_options.rb
+++ b/spec/support/shared_examples/raises_on_invalid_expire_command_options.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples_for 'raises on invalid expire command options' do |command|
+  [%i[nx xx], %i[nx lt], %i[nx gt], %i[lt gt]].each do |options|
+    context "with `#{options[0]}` and `#{options[1]}` options" do
+      it 'raises `Redis::CommandError`' do
+        expect { @mock.public_send(command, @key, 1, **options.zip([true, true]).to_h) }
+          .to raise_error(
+            Redis::CommandError,
+            'ERR NX and XX, GT or LT options at the same time are not compatible'
+          )
+      end
+    end
+
+    context 'with unexpected key' do
+      it 'raises `ArgumentError`' do
+        expect { @mock.public_send(command, @key, 1, foo: true) }
+          .to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/sds/mock_redis/issues/286

I also addes some specs to run against redis 7. Some of the existing specs fail, so I marked new specs with `redis: 7.0` tag.

Running `bundle exec rspec --tag redis:7.0` should run only redis-7-related specs, and running with `redis:6.2` or without tag at all should run all the specs except of redis-7-related. Not sure if this is an appropriate/optimal solution 