### PR TITLE
Require Ruby 3+

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.97.0
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         redis-version:
           - '6.2'
           - '7.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '3.0'
 
 Layout/ArgumentAlignment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 gemspec
 
 # Run all pre-commit hooks via Overcommit during CI runs
-gem 'overcommit', '0.53.0'
+gem 'overcommit', '0.61.0'
 
 # Pin tool versions (which are executed by Overcommit) for CI builds
 gem 'rubocop', '1.44.1'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for use in tests.
 
 ## Requirements
 
-Ruby 2.7+
+Ruby 3.0+
 
 The current implementation is tested against Redis 6.2. Older versions may work, but can also return different results or not support some commands.
 

--- a/lib/mock_redis/geospatial_methods.rb
+++ b/lib/mock_redis/geospatial_methods.rb
@@ -1,7 +1,7 @@
 class MockRedis
   module GeospatialMethods
-    LNG_RANGE = (-180..180).freeze
-    LAT_RANGE = (-85.05112878..85.05112878).freeze
+    LNG_RANGE = (-180..180)
+    LAT_RANGE = (-85.05112878..85.05112878)
     STEP = 26
     UNITS = {
       m: 1,

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_development_dependency 'rake', '~> 13'
   s.add_development_dependency 'redis', '~> 4.8.0'


### PR DESCRIPTION
Ruby 2.7 reached EoL in March 2023. It's time to drop support since our CI is now complaining about Bundler not supporting Ruby < 3.
