### PR TITLE
Cut version 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MockRedis Changelog
 
+### 0.42.0
+
+* Drop support for Ruby 2.x
+* Add support for `srem?`
+
 ### 0.41.0
 
 * Add support for `expire`-related command options `nx`/`xx`/`lt`/`gt`

--- a/lib/mock_redis/version.rb
+++ b/lib/mock_redis/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 class MockRedis
-  VERSION = '0.41.0'
+  VERSION = '0.42.0'
 end


### PR DESCRIPTION
* Drop support for Ruby 2.x
* Add support for `srem?`
