### PR TITLE
#292 extend set method to accept a third positional argument

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -212,8 +212,8 @@ class MockRedis
 
     # Parameter list required to ensure the ArgumentError is returned correctly
     # rubocop:disable Metrics/ParameterLists
-    def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil,
-      get: nil)
+    def set(key, value, _hash = nil, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil,
+      keepttl: nil, get: nil)
       key = key.to_s
       retval = self.get(key) if get
 

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -1,10 +1,24 @@
 require 'spec_helper'
 
-RSpec.describe '#set(key, value)' do
+RSpec.describe '#set(key, value, _hash)' do
   let(:key) { 'mock-redis-test' }
 
   it "responds with 'OK'" do
     expect(@redises.set('mock-redis-test', 1)).to eq('OK')
+  end
+
+  context 'when the positional argument _hash exists' do
+    it "responds with 'OK'" do
+      # Testing MockRedis.new.set instead of @redises.set
+      # because the latter doesn't align with Redis's set method.
+      # In mock_redis, set accepts a third positional argument, _hash,
+      # to accommodate the difference with redis-store's set method,
+      # which takes three positional arguments, unlike the standard Redis set.
+      # Reference:
+      # Redis: https://github.com/redis/redis-rb/blob/09acb9026ab2deaca4c851e0bcdb0ef9318b1ee0/lib/redis/commands/strings.rb#L83
+      # Redis-store: https://github.com/redis-store/redis-store/blob/5c3fee1b8fba672eb2bd5bfaedb973b68d12b773/lib/redis/store/ttl.rb#L4
+      expect(MockRedis.new.set('mock-redis-test', 1, { key: 'value' })).to eq('OK')
+    end
   end
 
   context 'options' do


### PR DESCRIPTION
# Summary
closes #292 

This pull request is for issue #292.
I extend set method to accept a third positional argument.


## Purpose of This Change

The primary goal of this change is to enhance the compatibility of the `mock_redis` `set` method with the `redis-store` `set` method. By introducing a third positional argument, we aim to align more closely with the `redis-store` implementation, facilitating easier integration and use in environments where `redis-store` is prevalent.

## Compatibility Concerns with Standard Redis

While the `redis-store` `set` method accepts three positional arguments, the standard Redis `set` method traditionally takes only two. This discrepancy could raise concerns about compatibility. However, this change ensures that compatibility with the standard Redis API is maintained and verified through existing tests in `set_spec.rb`. 


## Before and After the Change

### Before
The `set` method in `mock_redis` was defined as follows:
```ruby
def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
```
This definition aligns with the standard Redis API but lacks compatibility with the `redis-store` version.

### After
The revised `set` method is now defined with an additional third positional argument:
```ruby
def set(key, value, _hash = nil, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
```
This addition enables compatibility with `redis-store` without compromising the existing functionality with standard Redis.