### PR TITLE
Add support for `memory usage ...` command

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -12,6 +12,7 @@ require 'mock_redis/utility_methods'
 require 'mock_redis/geospatial_methods'
 require 'mock_redis/stream_methods'
 require 'mock_redis/connection_method'
+require 'mock_redis/memory_method'
 
 class MockRedis
   class Database
@@ -26,6 +27,7 @@ class MockRedis
     include GeospatialMethods
     include StreamMethods
     include ConnectionMethod
+    include MemoryMethod
 
     attr_reader :data, :expire_times
 

--- a/lib/mock_redis/memory_method.rb
+++ b/lib/mock_redis/memory_method.rb
@@ -1,0 +1,11 @@
+class MockRedis
+  module MemoryMethod
+    def memory(usage, key = nil, *_options)
+      raise ArgumentError, "unhandled command `memory #{usage}`" if usage != 'usage'
+
+      return nil unless @data.key?(key)
+
+      160
+    end
+  end
+end

--- a/spec/commands/memory_spec.rb
+++ b/spec/commands/memory_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe '#memory usage [mock only]' do
+  it 'only handles the usage subcommand' do
+    expect { @redises.mock.call(%w[memory stats]) }.to raise_error(ArgumentError)
+  end
+
+  context 'when the key does not exist' do
+    before { @redises.real.del('foo') }
+
+    it 'returns nil' do
+      expect(@redises.call(%w[memory usage foo])).to be_nil
+    end
+  end
+
+  context 'when the key does exist' do
+    before { @redises.set('foo', 'a' * 100) }
+
+    it 'returns the memory usage' do
+      expect(@redises.call(%w[memory usage foo])).to be_a(Integer)
+    end
+  end
+end


### PR DESCRIPTION
`MEMORY USAGE key` currently results in `NoMethodError: undefined method 'memory' for #<MockRedis::Database...`

This change will return a hardcoded numeric value

```console
> m = MockRedis.new
> m.call(["memory", "usage", "foo"])
=> nil

> m.set("foo", "anything")
=> "OK"

> m.call(["memory", "usage", "foo"])
=> 160
```