### PR TITLE
Fix `hset` for Array of Key / Value Pairs

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -137,6 +137,7 @@ class MockRedis
 
     def hset(key, *args)
       added = 0
+      args = args.flatten
       with_hash_at(key) do |hash|
         if args.length == 1 && args[0].is_a?(Hash)
           args = args[0].to_a.flatten

--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -137,7 +137,7 @@ class MockRedis
 
     def hset(key, *args)
       added = 0
-      args = args.flatten
+      args.flatten!(1)
       with_hash_at(key) do |hash|
         if args.length == 1 && args[0].is_a?(Hash)
           args = args[0].to_a.flatten

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -38,5 +38,17 @@ RSpec.describe '#hset(key, field)' do
     expect(@redises.hset(@key, { 'k1' => 'v1', 'k2' => 'v2' })).to eq(2)
   end
 
+  it 'stores array values correctly' do
+    @redises.hset(@key, ['k1', 'v1', 'k2', 'v2'])
+    expect(@redises.hget(@key, 'k1')).to eq('v1')
+    expect(@redises.hget(@key, 'k2')).to eq('v2')
+  end
+
+  it 'stores multiple arguments correctly' do
+    @redises.hset(@key, 'k1', 'v1', 'k2', 'v2')
+    expect(@redises.hget(@key, 'k1')).to eq('v1')
+    expect(@redises.hget(@key, 'k2')).to eq('v2')
+  end
+
   it_should_behave_like 'a hash-only command'
 end

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe '#hset(key, field)' do
   end
 
   it 'stores array values correctly' do
-    @redises.hset(@key, ['k1', 'v1', 'k2', 'v2'])
+    @redises.hset(@key, %w[k1 v1 k2 v2])
     expect(@redises.hget(@key, 'k1')).to eq('v1')
     expect(@redises.hget(@key, 'k2')).to eq('v2')
   end


### PR DESCRIPTION
Fixes https://github.com/sds/mock_redis/issues/310

This resolves an issue where `Redis` and `MockRedis` were storing values slightly differently:

## With Redis:
```ruby
require 'redis'
redis = Redis.new

hash = {:name=>"job", :namespace=>"default", :klass=>"Job"}
redis.hset("key", hash.flatten)

redis.hgetall("key")
=> {"name"=>"job", "namespace"=>"default", "klass"=>"Job"}
```

## With MockRedis (with this change):
```ruby
require 'mock_redis'
mock_redis = MockRedis.new

hash = {:name=>"job", :namespace=>"default", :klass=>"Job"}
mock_redis.hset("key", hash.flatten)

mock_redis.hgetall("key")
=> {"name"=>"job", "namespace"=>"default", "klass"=>"Job"}
```