### PR TITLE
Support Redis-rb v5

### DIFF
--- a/lib/mock_redis.rb
+++ b/lib/mock_redis.rb
@@ -1,6 +1,7 @@
 require 'set'
 
 require 'mock_redis/assertions'
+require 'mock_redis/error'
 require 'mock_redis/database'
 require 'mock_redis/expire_wrapper'
 require 'mock_redis/future'

--- a/lib/mock_redis/assertions.rb
+++ b/lib/mock_redis/assertions.rb
@@ -1,11 +1,27 @@
+require 'mock_redis/error'
+
 class MockRedis
+  DUMP_TYPES = RedisClient::RESP3::DUMP_TYPES
+
   module Assertions
     private
 
     def assert_has_args(args, command)
-      unless args.any?
-        raise Redis::CommandError,
-        "ERR wrong number of arguments for '#{command}' command"
+      if args.empty?
+        raise Error.command_error(
+          "ERR wrong number of arguments for '#{command}' command",
+          self
+        )
+      end
+    end
+
+    def assert_type(*args)
+      args.each do |arg|
+        DUMP_TYPES.fetch(arg.class) do |unexpected_class|
+          unless DUMP_TYPES.keys.find { |t| t > unexpected_class }
+            raise TypeError, "Unsupported command argument type: #{unexpected_class}"
+          end
+        end
       end
     end
   end

--- a/lib/mock_redis/error.rb
+++ b/lib/mock_redis/error.rb
@@ -1,0 +1,27 @@
+class MockRedis
+  module Error
+    module_function
+
+    def build(error_class, message, database)
+      connection = database.connection
+      url = "redis://#{connection[:host]}:#{connection[:port]}"
+      error_class.new("#{message} (#{url})")
+    end
+
+    def wrong_type_error(database)
+      build(
+        Redis::WrongTypeError,
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+        database
+      )
+    end
+
+    def syntax_error(database)
+      command_error('ERR syntax error', database)
+    end
+
+    def command_error(message, database)
+      build(Redis::CommandError, message, database)
+    end
+  end
+end

--- a/lib/mock_redis/sort_method.rb
+++ b/lib/mock_redis/sort_method.rb
@@ -5,7 +5,7 @@ class MockRedis
     include Assertions
 
     def sort(key, options = {})
-      return [] if key.nil?
+      assert_type(key)
 
       enumerable = data[key]
 

--- a/lib/mock_redis/stream_methods.rb
+++ b/lib/mock_redis/stream_methods.rb
@@ -35,6 +35,8 @@ class MockRedis
         stream.add id, entry
         stream.trim opts[:maxlen] if opts[:maxlen]
         return stream.last_id
+      rescue Redis::CommandError => e
+        raise Error.command_error(e.message, self)
       end
     end
 
@@ -55,6 +57,8 @@ class MockRedis
       args += ['COUNT', count] if count
       with_stream_at(key) do |stream|
         return stream.range(*args)
+      rescue Redis::CommandError => e
+        raise Error.command_error(e.message, self)
       end
     end
 
@@ -63,6 +67,8 @@ class MockRedis
       args += ['COUNT', count] if count
       with_stream_at(key) do |stream|
         return stream.range(*args)
+      rescue Redis::CommandError => e
+        raise Error.command_error(e.message, self)
       end
     end
 
@@ -94,8 +100,7 @@ class MockRedis
 
     def assert_streamy(key)
       unless streamy?(key)
-        raise Redis::CommandError,
-          'WRONGTYPE Operation against a key holding the wrong kind of value'
+        raise Error.wrong_type_error(self)
       end
     end
   end

--- a/mock_redis.gemspec
+++ b/mock_redis.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_development_dependency 'rake', '~> 13'
-  s.add_development_dependency 'redis', '~> 4.8.0'
+  s.add_development_dependency 'redis', '~> 5'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'
   s.add_development_dependency 'timecop', '~> 0.9.1'

--- a/spec/commands/blmove_spec.rb
+++ b/spec/commands/blmove_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe '#blmove(source, destination, wherefrom, whereto, timeout)' do
   it 'raises an error on negative timeout' do
     expect do
       @redises.blmove(@list1, @list2, 'left', 'right', :timeout => -1)
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   let(:default_error) { RedisMultiplexer::MismatchedResponse }

--- a/spec/commands/blpop_spec.rb
+++ b/spec/commands/blpop_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe '#blpop(key [, key, ...,], timeout)' do
   it 'raises an error on negative timeout' do
     expect do
       @redises.blpop(@list1, @list2, :timeout => -1)
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/brpop_spec.rb
+++ b/spec/commands/brpop_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe '#brpop(key [, key, ...,], timeout)' do
   it 'raises an error on negative timeout' do
     expect do
       @redises.brpop(@list1, @list2, :timeout => -1)
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a list-only command'

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe '#brpoplpush(source, destination, timeout)' do
+  let(:default_error) { ArgumentError }
+
   before do
     @list1 = 'mock-redis-test:brpoplpush1'
     @list2 = 'mock-redis-test:brpoplpush2'
@@ -25,7 +27,7 @@ RSpec.describe '#brpoplpush(source, destination, timeout)' do
   it 'raises an error on negative timeout' do
     expect do
       @redises.brpoplpush(@list1, @list2, :timeout => -1)
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a list-only command'
@@ -36,9 +38,10 @@ RSpec.describe '#brpoplpush(source, destination, timeout)' do
         to be_nil
     end
 
-    it 'ignores positive legacy timeouts and returns nil' do
-      expect(@redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1)).
-        to be_nil
+    it 'raises error if there is extra argument' do
+      expect do
+        @redises.mock.brpoplpush('mock-redis-test:not-here', @list1, 1)
+      end.to raise_error(ArgumentError)
     end
 
     it 'raises WouldBlock on zero timeout (no blocking in the mock)' do

--- a/spec/commands/connection_spec.rb
+++ b/spec/commands/connection_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe '#connection' do
   it 'returns the correct values' do
     expect(redis.connection).to eq(
       {
-        :host => '127.0.0.1',
+        :host => 'localhost',
         :port => 6379,
         :db => 0,
-        :id => 'redis://127.0.0.1:6379/0',
-        :location => '127.0.0.1:6379'
+        :id => 'redis://localhost:6379/0',
+        :location => 'localhost:6379'
       }
     )
   end

--- a/spec/commands/expire_spec.rb
+++ b/spec/commands/expire_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#expire(key, seconds)' do
   it 'raises an error if seconds is bogus' do
     expect do
       @redises.expire(@key, 'a couple minutes or so')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'stringifies key' do

--- a/spec/commands/expireat_spec.rb
+++ b/spec/commands/expireat_spec.rb
@@ -19,10 +19,8 @@ RSpec.describe '#expireat(key, timestamp)' do
     expect(@redises.get(@key)).to be_nil
   end
 
-  it "raises an error if you don't give it a Unix timestamp" do
-    expect do
-      @redises.expireat(@key, Time.now) # oops, forgot .to_i
-    end.to raise_error(Redis::CommandError)
+  it 'returns true when time is a Time object' do
+    expect(@redises.expireat(@key, Time.now)).to eq true
   end
 
   it 'works with options', redis: '7.0' do

--- a/spec/commands/geoadd_spec.rb
+++ b/spec/commands/geoadd_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe '#geoadd' do
     end
   end
 
-  context 'with invalud points' do
+  context 'with invalid points' do
     context 'when number of arguments wrong' do
-      let(:message) { "ERR wrong number of arguments for 'geoadd' command" }
+      let(:message) { /ERR wrong number of arguments for 'geoadd' command/ }
 
       it 'raises Redis::CommandError' do
         expect { @redises.geoadd(key, 1, 1) }
@@ -34,7 +34,7 @@ RSpec.describe '#geoadd' do
       let(:coords) { [181, 86] }
       let(:message) do
         formatted_coords = coords.map { |c| format('%<coords>.6f', coords: c) }
-        "ERR invalid longitude,latitude pair #{formatted_coords.join(',')}"
+        /ERR invalid longitude,latitude pair #{formatted_coords.join(',')}/
       end
 
       after { @redises.zrem(key, 'SF') }
@@ -47,7 +47,7 @@ RSpec.describe '#geoadd' do
 
     context 'when coordinates are not valid floats' do
       let(:coords) { ['x', 35] }
-      let(:message) { 'ERR value is not a valid float' }
+      let(:message) { /ERR value is not a valid float/ }
 
       it 'raises Redis::CommandError' do
         expect { @redises.geoadd key, *coords, 'SF' }

--- a/spec/commands/geodist_spec.rb
+++ b/spec/commands/geodist_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe '#geodist' do
   end
 
   context 'with wrong unit' do
-    let(:message) { 'ERR unsupported unit provided. please use m, km, ft, mi' }
+    let(:message) { /ERR unsupported unit provided. please use m, km, ft, mi/ }
 
     it 'raises an error' do
       expect { @redises.geodist(key, 'SF', 'LA', 'a') }

--- a/spec/commands/hdel_spec.rb
+++ b/spec/commands/hdel_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe '#hdel(key, field)' do
   it 'raises error if an empty array is passed' do
     expect { @redises.hdel(@key, []) }.to raise_error(
       Redis::CommandError,
-      "ERR wrong number of arguments for 'hdel' command"
+      /ERR wrong number of arguments for 'hdel' command/
     )
   end
 

--- a/spec/commands/hincrby_spec.rb
+++ b/spec/commands/hincrby_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe '#hincrby(key, field, increment)' do
   it 'raises an error if the delta does not look like an integer' do
     expect do
       @redises.hincrby(@key, @field, 'foo')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hincrbyfloat_spec.rb
+++ b/spec/commands/hincrbyfloat_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe '#hincrbyfloat(key, field, increment)' do
   it 'raises an error if the delta does not look like a float' do
     expect do
       @redises.hincrbyfloat(@key, @field, 'foobar.baz')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a hash-only command'

--- a/spec/commands/hset_spec.rb
+++ b/spec/commands/hset_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe '#hset(key, field)' do
     expect(@redises.hget(@key, 'k2')).to eq('v2')
   end
 
+  it 'raises error when key is nil' do
+    expect do
+      @redises.hset(nil, 'abc')
+    end.to raise_error(TypeError)
+  end
+
+  it 'raises error when hash key is nil' do
+    expect do
+      @redises.hset(@key, nil, 'abc')
+    end.to raise_error(TypeError)
+  end
+
   it 'stores multiple arguments correctly' do
     @redises.hset(@key, 'k1', 'v1', 'k2', 'v2')
     expect(@redises.hget(@key, 'k1')).to eq('v1')

--- a/spec/commands/incrby_spec.rb
+++ b/spec/commands/incrby_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe '#incrby(key, increment)' do
   it 'raises an error if the delta does not look like an integer' do
     expect do
       @redises.incrby(@key, 'foo')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/incrbyfloat_spec.rb
+++ b/spec/commands/incrbyfloat_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe '#incrbyfloat(key, increment)' do
   it 'raises an error if the delta does not look like an float' do
     expect do
       @redises.incrbyfloat(@key, 'foobar.baz')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/linsert_spec.rb
+++ b/spec/commands/linsert_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe '#linsert(key, :before|:after, pivot, value)' do
+  let(:default_error) { Redis::CommandError }
+
   before { @key = 'mock-redis-test:48733' }
 
   it 'returns the new size of the list when the pivot is found' do

--- a/spec/commands/lmove_spec.rb
+++ b/spec/commands/lmove_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe '#lmove(source, destination, wherefrom, whereto)' do
     end.to raise_error(Redis::CommandError)
   end
 
+  it 'raises error if wherefrom is not left or right' do
+    expect do
+      @redises.lmove(@list1, @list2, 'oops', 'right')
+    end.to raise_error(ArgumentError, "where_source must be 'LEFT' or 'RIGHT'")
+  end
+
+  it 'raises error if whereto is not left or right' do
+    expect do
+      @redises.lmove(@list1, @list2, 'left', 'oops')
+    end.to raise_error(ArgumentError, "where_destination must be 'LEFT' or 'RIGHT'")
+  end
+
   let(:default_error) { RedisMultiplexer::MismatchedResponse }
   it_should_behave_like 'a list-only command'
 end

--- a/spec/commands/lrem_spec.rb
+++ b/spec/commands/lrem_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe '#lrem(key, count, value)' do
   it 'raises an error if the value does not look like an integer' do
     expect do
       @redises.lrem(@key, 'foo', 'bottles')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'removes empty lists' do

--- a/spec/commands/mapped_hmget_spec.rb
+++ b/spec/commands/mapped_hmget_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe '#mapped_hmget(key, *fields)' do
       to eq({ 'k1' => 'v1', 'mock-redis-test:nonesuch' => nil })
   end
 
-  it 'treats an array as the first key' do
-    expect(@redises.mapped_hmget(@key, %w[k1 k2])).to eq({ %w[k1 k2] => 'v1' })
+  it 'treats an array as multiple keys' do
+    expect(@redises.mapped_hmget(@key, %w[k1 k2])).to eq({ 'k1' => 'v1', 'k2' => 'v2' })
   end
 
   it 'raises an error if given no fields' do

--- a/spec/commands/pexpire_spec.rb
+++ b/spec/commands/pexpire_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#pexpire(key, ms)' do
   it 'raises an error if ms is bogus' do
     expect do
       @redises.pexpire(@key, 'a couple minutes or so')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(ArgumentError)
   end
 
   it 'works with options', redis: '7.0' do

--- a/spec/commands/pexpireat_spec.rb
+++ b/spec/commands/pexpireat_spec.rb
@@ -24,10 +24,8 @@ RSpec.describe '#pexpireat(key, timestamp_ms)' do
     expect(@redises.get(@key)).to be_nil
   end
 
-  it "raises an error if you don't give it a Unix timestamp" do
-    expect do
-      @redises.pexpireat(@key, Time.now) # oops, forgot .to_i
-    end.to raise_error(Redis::CommandError)
+  it 'returns true when time object is provided' do
+    expect(@redises.pexpireat(@key, Time.now)).to eq true
   end
 
   it 'works with options', redis: '7.0' do

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe '#pipelined' do
     end
 
     it 'returns an array of the array replies' do
-      results = @redises.pipelined do |_redis|
-        @redises.lrange(key1, 0, -1)
-        @redises.lrange(key2, 0, -1)
+      results = @redises.pipelined do |redis|
+        redis.lrange(key1, 0, -1)
+        redis.lrange(key2, 0, -1)
       end
 
       expect(results).to eq([value1, value2])

--- a/spec/commands/psetex_spec.rb
+++ b/spec/commands/psetex_spec.rb
@@ -27,18 +27,22 @@ RSpec.describe '#psetex(key, miliseconds, value)' do
   end
 
   context 'when expiration time is zero' do
+    let(:message) { /ERR invalid expire time in psetex/ }
+
     it 'raises Redis::CommandError' do
       expect do
         @redises.psetex(@key, 0, 'value')
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in psetex')
+      end.to raise_error(Redis::CommandError, message)
     end
   end
 
   context 'when expiration time is negative' do
+    let(:message) { /ERR invalid expire time in psetex/ }
+
     it 'raises Redis::CommandError' do
       expect do
         @redises.psetex(@key, -2, 'value')
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in psetex')
+      end.to raise_error(Redis::CommandError, message)
     end
   end
 end

--- a/spec/commands/renamenx_spec.rb
+++ b/spec/commands/renamenx_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe '#renamenx(key, newkey)' do
   it 'raises an error when the source key is nonexistant' do
     @redises.del(@key)
     expect do
-      @redises.rename(@key, @newkey)
+      @redises.renamenx(@key, @newkey)
     end.to raise_error(Redis::CommandError)
   end
 

--- a/spec/commands/rpop_spec.rb
+++ b/spec/commands/rpop_spec.rb
@@ -60,7 +60,10 @@ RSpec.describe '#rpop(key)' do
   it_should_behave_like 'a list-only command' do
     let(:args) { [1] }
     let(:error) do
-      [Redis::CommandError, 'WRONGTYPE Operation against a key holding the wrong kind of value']
+      [
+        Redis::CommandError,
+        /WRONGTYPE Operation against a key holding the wrong kind of value/
+      ]
     end
   end
 end

--- a/spec/commands/sadd_spec.rb
+++ b/spec/commands/sadd_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe '#sadd(key, member)' do
 
   context 'sadd' do
     it 'returns true if the set did not already contain member' do
-      expect(@redises.sadd(@key, 1)).to eq(true)
+      expect(@redises.sadd(@key, 1)).to eq(1)
     end
 
     it 'returns false if the set did already contain member' do
       @redises.sadd(@key, 1)
-      expect(@redises.sadd(@key, 1)).to eq(false)
+      expect(@redises.sadd(@key, 1)).to eq(0)
     end
 
     it 'adds member to the set' do
@@ -55,7 +55,7 @@ RSpec.describe '#sadd(key, member)' do
 
     it 'adds an Array as a stringified member' do
       @redises.sadd(@key, [[1], 2, 3])
-      expect(@redises.smembers(@key)).to eq(%w[[1] 2 3])
+      expect(@redises.smembers(@key)).to eq(%w[1 2 3])
     end
 
     it 'raises an error if an empty array is given' do

--- a/spec/commands/set_spec.rb
+++ b/spec/commands/set_spec.rb
@@ -25,25 +25,25 @@ RSpec.describe '#set(key, value, _hash)' do
     it 'raises an error for EX seconds = 0' do
       expect do
         @redises.set('mock-redis-test', 1, ex: 0)
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in set')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in set/)
     end
 
     it 'raises an error for PX milliseconds = 0' do
       expect do
         @redises.set('mock-redis-test', 1, px: 0)
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in set')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in set/)
     end
 
     it 'raises an error for EXAT seconds = 0' do
       expect do
         @redises.set('mock-redis-test', 1, exat: 0)
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in set')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in set/)
     end
 
     it 'raises an error for PXAT seconds = 0' do
       expect do
         @redises.set('mock-redis-test', 1, pxat: 0)
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in set')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in set/)
     end
 
     it 'accepts NX' do

--- a/spec/commands/setbit_spec.rb
+++ b/spec/commands/setbit_spec.rb
@@ -51,5 +51,5 @@ RSpec.describe '#setbit(key, offset)' do
     expect(@redises.getbit(@key, 23)).to eq(0)
   end
 
-  it_should_behave_like 'a string-only command'
+  it_should_behave_like 'a string-only command', Redis::CommandError
 end

--- a/spec/commands/setex_spec.rb
+++ b/spec/commands/setex_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe '#setex(key, seconds, value)' do
     it 'raises Redis::CommandError' do
       expect do
         @redises.setex(@key, 0, 'value')
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in setex')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in setex/)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe '#setex(key, seconds, value)' do
     it 'raises Redis::CommandError' do
       expect do
         @redises.setex(@key, -2, 'value')
-      end.to raise_error(Redis::CommandError, 'ERR invalid expire time in setex')
+      end.to raise_error(Redis::CommandError, /ERR invalid expire time in setex/)
     end
   end
 end

--- a/spec/commands/sinter_spec.rb
+++ b/spec/commands/sinter_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe '#sinter(key [, key, ...])' do
     expect(@redises.sinter(@evens, @primes)).to eq(['2'])
   end
 
-  it 'treats missing keys as empty sets' do
-    expect(@redises.sinter(@destination, 'mock-redis-test:nonesuch')).to eq([])
+  it 'raises error when key is not set' do
+    expect do
+      @redises.sinter(nil, 'mock-redis-test:nonesuch')
+    end.to raise_error(TypeError)
   end
 
   it 'raises an error if given 0 sets' do

--- a/spec/commands/srem_spec.rb
+++ b/spec/commands/srem_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe '#srem(key, member)' do
   end
 
   it 'returns true if member is in the set' do
-    expect(@redises.srem(@key, 'bert')).to eq(true)
+    expect(@redises.srem(@key, 'bert')).to eq(1)
   end
 
   it 'returns false if member is not in the set' do
-    expect(@redises.srem(@key, 'cookiemonster')).to eq(false)
+    expect(@redises.srem(@key, 'cookiemonster')).to eq(0)
   end
 
   it 'removes member from the set' do
@@ -23,7 +23,7 @@ RSpec.describe '#srem(key, member)' do
 
   it 'stringifies member' do
     @redises.sadd(@key, '1')
-    expect(@redises.srem(@key, 1)).to eq(true)
+    expect(@redises.srem(@key, 1)).to eq(1)
   end
 
   it 'cleans up empty sets' do

--- a/spec/commands/sunion_spec.rb
+++ b/spec/commands/sunion_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe '#sunion(key [, key, ...])' do
     @redises.set('mock-redis-test:notset', 1)
 
     expect do
-      @redises.sunion(@numbers, 'mock-redis-test:notset')
-    end.to raise_error(Redis::CommandError)
+      @redises.sunion(nil, 'mock-redis-test:notset')
+    end.to raise_error(TypeError)
 
     expect do
-      @redises.sunion('mock-redis-test:notset', @numbers)
-    end.to raise_error(Redis::CommandError)
+      @redises.sunion('mock-redis-test:notset', nil)
+    end.to raise_error(TypeError)
   end
 end

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, '\
     expect { @redises.xadd(@key, { key: 'value' }, id: '1234567891233-0') }
       .to raise_error(
         Redis::CommandError,
-        'ERR The ID specified in XADD is equal or smaller than the target ' \
-        'stream top item'
+        /ERR The ID specified in XADD is equal or smaller than the target stream top item/
       )
   end
 
@@ -56,7 +55,7 @@ RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, '\
     expect { @redises.xadd('mock-redis-test:unknown-stream', { key: 'value' }, id: '0') }
       .to raise_error(
         Redis::CommandError,
-        'ERR The ID specified in XADD must be greater than 0-0'
+        /ERR The ID specified in XADD must be greater than 0-0/
       )
   end
 
@@ -80,7 +79,7 @@ RSpec.describe '#xadd("mystream", { f1: "v1", f2: "v2" }, '\
     expect { @redises.xadd(@key, { key: 'value' }, id: 'X') }
       .to raise_error(
         Redis::CommandError,
-        'ERR Invalid stream ID specified as stream command argument'
+        /ERR Invalid stream ID specified as stream command argument/
       )
   end
 

--- a/spec/commands/xrange_spec.rb
+++ b/spec/commands/xrange_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe '#xrange("mystream", first: "0-1", last: "0-3", count: 10)' do
     expect { @redises.xrange(@key, 'X', '+') }
       .to raise_error(
         Redis::CommandError,
-        'ERR Invalid stream ID specified as stream command argument'
+        /ERR Invalid stream ID specified as stream command argument/
       )
   end
 end

--- a/spec/commands/xrevrange_spec.rb
+++ b/spec/commands/xrevrange_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe '#xrevrange(key, start, end)' do
     expect { @redises.xrevrange(@key, 'X', '-') }
       .to raise_error(
         Redis::CommandError,
-        'ERR Invalid stream ID specified as stream command argument'
+        /ERR Invalid stream ID specified as stream command argument/
       )
   end
 end

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -119,9 +119,13 @@ RSpec.describe '#zadd(key, score, member)' do
   end
 
   it 'no longer raises an error if an empty array is given' do
+    expect(@redises.zadd(@key, [])).to eq(0)
+  end
+
+  it 'raises error if no argument is set' do
     expect do
-      @redises.zadd(@key, [])
-    end.not_to raise_error(Redis::CommandError)
+      @redises.zadd(@key)
+    end.to raise_error(ArgumentError)
   end
 
   it_should_behave_like 'arg 1 is a score'

--- a/spec/commands/zrem_spec.rb
+++ b/spec/commands/zrem_spec.rb
@@ -41,9 +41,7 @@ RSpec.describe '#zrem(key, member)' do
   end
 
   it 'no longer raises an error if member is an empty array' do
-    expect do
-      @redises.zrem(@key, [])
-    end.not_to raise_error(Redis::CommandError)
+    expect(@redises.zrem(@key, [])).to eq 0
   end
 
   it_should_behave_like 'a zset-only command'

--- a/spec/commands/zremrangebyscore_spec.rb
+++ b/spec/commands/zremrangebyscore_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe '#zremrangebyscore(key, min, max)' do
 
   it_should_behave_like 'a zset-only command'
 
-  it 'throws a command error' do
+  it 'throws a type error' do
     expect do
       @redises.zrevrangebyscore(@key, DateTime.now, '-inf')
-    end.to raise_error(Redis::CommandError)
+    end.to raise_error(TypeError)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   config.include(TypeCheckingHelper)
 
   config.before(:all) do
-    @redises = RedisMultiplexer.new
+    @redises = RedisMultiplexer.new(url: 'redis://localhost:6379')
   end
 
   config.before(:each) do

--- a/spec/support/redis_multiplexer.rb
+++ b/spec/support/redis_multiplexer.rb
@@ -10,7 +10,6 @@ class RedisMultiplexer < BlankSlate
   def initialize(*a)
     super()
     @mock_redis = MockRedis.new(*a)
-    Redis.exists_returns_integer = true
     @real_redis = Redis.new(*a)
     _gsub_clear
   end

--- a/spec/support/shared_examples/does_not_cleanup_empty_strings.rb
+++ b/spec/support/shared_examples/does_not_cleanup_empty_strings.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples_for 'does not remove empty strings on error' do
   let(:method) { |example| method_from_description(example) }
   let(:args) { args_for_method(method) }
-  let(:error) { defined?(default_error) ? default_error : RuntimeError }
+  let(:error) { defined?(default_error) ? default_error : Redis::WrongTypeError }
 
   it 'does not remove empty strings on error' do
     key = 'mock-redis-test:not-a-string'

--- a/spec/support/shared_examples/only_operates_on_hashes.rb
+++ b/spec/support/shared_examples/only_operates_on_hashes.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples_for 'a hash-only command' do
     @redises.set(key, 1)
     expect do
       @redises.send(method, *args)
-    end.to raise_error(RuntimeError)
+    end.to raise_error(Redis::WrongTypeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'

--- a/spec/support/shared_examples/only_operates_on_sets.rb
+++ b/spec/support/shared_examples/only_operates_on_sets.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples_for 'a set-only command' do
     @redises.set(key, 1)
     expect do
       @redises.send(method, *args)
-    end.to raise_error(RuntimeError)
+    end.to raise_error(Redis::WrongTypeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'

--- a/spec/support/shared_examples/only_operates_on_strings.rb
+++ b/spec/support/shared_examples/only_operates_on_strings.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples_for 'a string-only command' do
+RSpec.shared_examples_for 'a string-only command' do |expected_error = Redis::WrongTypeError|
   it 'raises an error for non-string values' do |example|
     key = 'mock-redis-test:string-only-command'
 
@@ -8,6 +8,6 @@ RSpec.shared_examples_for 'a string-only command' do
     @redises.lpush(key, 1)
     expect do
       @redises.send(method, *args)
-    end.to raise_error(RuntimeError)
+    end.to raise_error(expected_error)
   end
 end

--- a/spec/support/shared_examples/only_operates_on_zsets.rb
+++ b/spec/support/shared_examples/only_operates_on_zsets.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples_for 'a zset-only command' do
     @redises.set(key, 1)
     expect do
       @redises.send(method, *args)
-    end.to raise_error(RuntimeError)
+    end.to raise_error(Redis::WrongTypeError)
   end
 
   it_should_behave_like 'does not remove empty strings on error'
@@ -54,6 +54,6 @@ RSpec.shared_examples_for 'arg N is a score' do
 
   it 'rejects non-numbers' do
     @args[@_arg_index] = 'foo'
-    expect { @redises.send(@method, *@args) }.to raise_error(RuntimeError)
+    expect { @redises.send(@method, *@args) }.to raise_error(Redis::CommandError)
   end
 end

--- a/spec/support/shared_examples/raises_on_invalid_expire_command_options.rb
+++ b/spec/support/shared_examples/raises_on_invalid_expire_command_options.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for 'raises on invalid expire command options' do |command
         expect { @mock.public_send(command, @key, 1, **options.zip([true, true]).to_h) }
           .to raise_error(
             Redis::CommandError,
-            'ERR NX and XX, GT or LT options at the same time are not compatible'
+            /ERR NX and XX, GT or LT options at the same time are not compatible/
           )
       end
     end

--- a/spec/support/shared_examples/sorts_enumerables.rb
+++ b/spec/support/shared_examples/sorts_enumerables.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples_for 'a sortable' do
   it 'returns empty array on nil' do
-    expect(@redises.sort(nil)).to eq([])
+    expect { @redises.sort(nil) }.to raise_error(TypeError)
   end
 
   context 'ordering' do


### PR DESCRIPTION
This is an attempt to fix https://github.com/sds/mock_redis/issues/281. This PR was also tested using the test suite of our service.

There are a few decisions I made regarding this PR, please let me know if it's not appropriate:

1. Error from Redis now contains the redis connection URL
  - To fix this, I created `MockRedis::Error` module which decorate `Redis::CommandError` and related errors with the connection URL
  - I replace most of the `Redis::CommandError` with the new module wrapper
2. Some methods now return integer as output instead of boolean and `exists_returns_integer` is removed
  - I replace the output as is
3. Interfaces of most data structures (Hash, Set, ...) now validate type to be 4 main primitive types
  - `assert_type` is added to validate the arguments. Currently it doesn't look very clean, so any improvements would be great.
4. `sadd`, `srem` now support multiple arguments
5. Transaction: `multi` now needs to call with a block and `discard`/`exec` cannot be called outside that block anymore
  - I tried to refactor the logic to make the tests pass, but I'm not entirely confident that it works correctly
