### PR TITLE
Require redid-client to ensure that constant is available

### DIFF
--- a/lib/mock_redis/assertions.rb
+++ b/lib/mock_redis/assertions.rb
@@ -1,3 +1,4 @@
+require 'redis-client'
 require 'mock_redis/error'
 
 class MockRedis


### PR DESCRIPTION
Fix https://github.com/sds/mock_redis/issues/318