### PR TITLE
allow #call to accept array or multiple arguments

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -48,7 +48,8 @@ class MockRedis
     # FIXME: Current implementation of `call` does not work propetly with kwarg-options.
     # i.e. `call("EXPIRE", "foo", 40, "NX")` (which redis-rb will simply transmit to redis-server)
     # will be passed to `#expire` without keywords transformation.
-    def call(command, &_block)
+    def call(*command, &_block)
+      command = command[0] if command.length == 1 # allow for single array argument or multiple arguments
       public_send(command[0].downcase, *command[1..])
     end
 

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -142,5 +142,15 @@ RSpec.describe '#pipelined' do
 
       expect(results).to eq([value1, 'OK', 'foobar'])
     end
+
+    it 'works correctly with mixed-case commands not using array' do
+      results = @redises.pipelined do |redis|
+        redis.call('Get', key1)
+        redis.call('SET', key2, 'foobar')
+        redis.call('gET', key2)
+      end
+
+      expect(results).to eq([value1, 'OK', 'foobar'])
+    end
   end
 end


### PR DESCRIPTION
Possible fix for https://github.com/sds/mock_redis/issues/323