### PR TITLE
Accept symbols for `scan(type:)` option, like redis-rb

### DIFF
--- a/lib/mock_redis/utility_methods.rb
+++ b/lib/mock_redis/utility_methods.rb
@@ -28,7 +28,7 @@ class MockRedis
       cursor = cursor.to_i
       match = opts[:match] || '*'
       key = opts[:key] || lambda { |x| x }
-      type_opt = opts[:type]
+      type_opt = opts[:type]&.to_s
       filtered_values = []
 
       limit = cursor + count


### PR DESCRIPTION
Currently, the following example has different results when run on `redis-rb` or `mock-redis` : 
```ruby
$redis.zadd("test/sorted_set", 123, "value")
$redis.scan(0, match: 'test/*')
$redis.scan(0, match: 'test/*', type: :zset)
```

With `redis-rb` the result is the following : 
```ruby
true
["0", ["test/sorted_set"]]
["0", ["test/sorted_set"]]
```

With `redis-mock` : 
```ruby
true
["0", ["test/sorted_set"]]
["0", []]
```