### PR TITLE
allow #call to accept array or multiple arguments

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -48,7 +48,8 @@ class MockRedis
     # FIXME: Current implementation of `call` does not work propetly with kwarg-options.
     # i.e. `call("EXPIRE", "foo", 40, "NX")` (which redis-rb will simply transmit to redis-server)
     # will be passed to `#expire` without keywords transformation.
-    def call(command, &_block)
+    def call(*command, &_block)
+      command = command[0] if command.length == 1 # allow for single array argument or multiple arguments
       public_send(command[0].downcase, *command[1..])
     end
 

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -49,7 +49,8 @@ class MockRedis
     # i.e. `call("EXPIRE", "foo", 40, "NX")` (which redis-rb will simply transmit to redis-server)
     # will be passed to `#expire` without keywords transformation.
     def call(*command, &_block)
-      command = command[0] if command.length == 1 # allow for single array argument or multiple arguments
+      # allow for single array argument or multiple arguments
+      command = command[0] if command.length == 1
       public_send(command[0].downcase, *command[1..])
     end
 

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe '#brpoplpush(source, destination, timeout)' do
-  let(:default_error) { ArgumentError }
-
   before do
     @list1 = 'mock-redis-test:brpoplpush1'
     @list2 = 'mock-redis-test:brpoplpush2'
@@ -30,7 +28,6 @@ RSpec.describe '#brpoplpush(source, destination, timeout)' do
     end.to raise_error(ArgumentError)
   end
 
-  let(:default_error) { Redis::WrongTypeError }
   it_should_behave_like 'a list-only command'
 
   context '[mock only]' do

--- a/spec/commands/brpoplpush_spec.rb
+++ b/spec/commands/brpoplpush_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe '#brpoplpush(source, destination, timeout)' do
     end.to raise_error(ArgumentError)
   end
 
+  let(:default_error) { Redis::WrongTypeError }
   it_should_behave_like 'a list-only command'
 
   context '[mock only]' do

--- a/spec/commands/lpop_spec.rb
+++ b/spec/commands/lpop_spec.rb
@@ -61,6 +61,5 @@ RSpec.describe '#lpop(key)' do
     end
   end
 
-  let(:default_error) { ArgumentError }
   it_should_behave_like 'a list-only command'
 end

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -142,5 +142,15 @@ RSpec.describe '#pipelined' do
 
       expect(results).to eq([value1, 'OK', 'foobar'])
     end
+
+    it 'works correctly with mixed-case commands not using array' do
+      results = @redises.pipelined do |redis|
+        redis.call('Get', key1)
+        redis.call('SET', key2, 'foobar')
+        redis.call('gET', key2)
+      end
+
+      expect(results).to eq([value1, 'OK', 'foobar'])
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,11 +33,11 @@ module TypeCheckingHelper
   end
 
   def args_for_method(method)
-    # using parameters instead of arity because arity cannot properly account for keyword vs positional arguments
-    # when it is negative arity
+    # using parameters instead of arity because arity cannot properly account for keyword vs
+    # positional arguments when it is negative arity
     parameters = @redises.real.method(method).parameters
-    base_parameters = parameters.count{ |type, _| type == :req || type == :opt }
-    rest_params = parameters.count{ |type, _| type == :rest }
+    base_parameters = parameters.count { |type, _| [:req, :opt].include?(type) }
+    rest_params = parameters.count { |type, _| type == :rest }
     total_params = (rest_params * 2) + base_parameters
 
     (1..(total_params - 1)).to_a

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,13 +33,14 @@ module TypeCheckingHelper
   end
 
   def args_for_method(method)
-    return [] if %w[spop zpopmin zpopmax].include?(method.to_s)
-    method_arity = @redises.real.method(method).arity
-    if method_arity < 0 # -1 comes from def foo(*args)
-      [1, 2] # probably good enough
-    else
-      1.upto(method_arity - 1).to_a
-    end
+    # using parameters instead of arity because arity cannot properly account for keyword vs positional arguments
+    # when it is negative arity
+    parameters = @redises.real.method(method).parameters
+    base_parameters = parameters.count{ |type, _| type == :req || type == :opt }
+    rest_params = parameters.count{ |type, _| type == :rest }
+    total_params = (rest_params * 2) + base_parameters
+
+    (1..(total_params - 1)).to_a
   end
 end
 


### PR DESCRIPTION
Fix for https://github.com/sds/mock_redis/issues/323

https://github.com/sds/mock_redis/pull/324 with specs fixed. Problem was that the arity of some methods changed from `redis 5.3.0` to `redis 5.4.0` due to https://github.com/redis/redis-rb/pull/1300