### PR TITLE
Faster hmget when fetching a lot of fields

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -93,7 +93,7 @@ class MockRedis
 
       assert_type(key, *fields)
       assert_has_args(fields, 'hmget')
-      fields.map { |f| hget(key, f) }
+      with_hash_at(key) { |h| h.values_at(*fields.map(&:to_s)) }
     end
 
     def mapped_hmget(key, *fields)

--- a/spec/commands/hmget_spec.rb
+++ b/spec/commands/hmget_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe '#hmget(key, field [, field, ...])' do
     expect(@redises.hmget(@key, %w[k1 k2]).sort).to eq(%w[v1 v2])
   end
 
-  it 'treats the fielsd as strings' do
+  it 'treats the fields as strings' do
     @redises.hset(@key, 1, 'one')
     @redises.hset(@key, 2, 'two')
     expect(@redises.hmget(@key, 1, 2).sort).to eq(%w[one two])


### PR DESCRIPTION
The previous version of `hmget` calls `hget` for each field being fetched, but that results in a lot of redundant calls to `with_hash_at` (and in turn, `clean_up_empties_at`, which is not especially fast).

Change it to just use a single `with_hash_at` call.


```ruby
days = 1.upto(365).map(&:to_s)
redis = MockRedis.new
Benchmark.ips do |x|
  x.report("v1") { redis.hmget("views_by_year:2025", *days) }
  x.report("v2") { redis.hmget2("views_by_year:2025", *days) }
  x.compare!
end

# ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [arm64-darwin24]
# Warming up --------------------------------------
#                 v1    60.000 i/100ms
#                 v2   796.000 i/100ms
# Calculating -------------------------------------
#                 v1    608.372 (± 1.3%) i/s    (1.64 ms/i) -      3.060k in   5.030757s
#                 v2      8.212k (± 8.7%) i/s  (121.78 μs/i) -     41.392k in   5.087108s
# 
# Comparison:
#                 v2:     8211.7 i/s
#                 v1:      608.4 i/s - 13.50x  slower
```