### PR TITLE
Fix `Database.call` with expire methods

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -51,7 +51,12 @@ class MockRedis
     def call(*command, &_block)
       # allow for single array argument or multiple arguments
       command = command[0] if command.length == 1
-      public_send(command[0].downcase, *command[1..])
+
+      if command[0].downcase.to_s.include?('expire')
+        send_expires(command)
+      else
+        public_send(command[0].downcase, *command[1..])
+      end
     end
 
     def auth(_)
@@ -349,6 +354,11 @@ class MockRedis
 
     def looks_like_float?(str)
       !!Float(str) rescue false
+    end
+
+    def send_expires(command)
+      command, key, ttl, option = *command
+      public_send(command, key, ttl, option.downcase.to_sym => option)
     end
 
     def should_update_expiration?(expiry, new_expiry, nx:, xx:, lt:, gt:) # rubocop:disable Metrics/ParameterLists

--- a/spec/commands/pexpireat_spec.rb
+++ b/spec/commands/pexpireat_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe '#pexpireat(key, timestamp_ms)' do
   end
 
   it 'removes a key immediately when timestamp is now' do
+    # Solves inconsistent failures when running test one after another
+    sleep 0.001
     @redises.pexpireat(@key, now_ms)
     expect(@redises.get(@key)).to be_nil
   end


### PR DESCRIPTION
# What?
* It fixes calls to `expire*` methods when the calling happens through the `.call` method of MockRedis::Database
* It fixes a test that will inconsistently fail when we run tests one after another, within a few seconds of each run

# Why?
`expire` values are not respected when we set these via the Database object. So tests that depend on testing that we set the ttl correctly will fail. This happens because the `.call` method fails to call successfully `public_send` due to the need to parse out the kwarg arguments.

# How?
The fix was to identify if we have an `expire` call in the command. If that is the case, we call a `send_expire` method that will correctly transform the call so that we can call those methods with the correct format.

For the test, I noticed that adding a slight wait for 1 millisecond was enough to consistently get that test passed

# Notes

I didn't add a version number because I didn't want to be be arrogant and assume that the PR will be passed. I am happy to modify things or try some other solution if you prefer that.

Thanks so much for such a useful gem 