### PR TITLE
Fixes for redis.call("info")

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -52,10 +52,15 @@ class MockRedis
       # flatten any nested arrays (eg from [:call, ["GET", "X"]] in pipelined commands)
       command = command.flatten
 
-      if command[0].downcase.to_s.include?('expire')
+      cmd_name = command[0].downcase.to_s
+
+      if cmd_name.include?('expire')
         send_expires(command)
+      elsif cmd_name == 'info'
+        # call(:info) returns a string, not a parsed hash
+        info_raw(*command[1..])
       else
-        public_send(command[0].downcase, *command[1..])
+        public_send(cmd_name, *command[1..])
       end
     end
 

--- a/lib/mock_redis/info_method.rb
+++ b/lib/mock_redis/info_method.rb
@@ -125,36 +125,65 @@ class MockRedis
     }.freeze
     # rubocop:enable Layout/LineLength
 
-    DEFAULT_INFO = [
-      SERVER_INFO,
-      CLIENTS_INFO,
-      MEMORY_INFO,
-      PERSISTENCE_INFO,
-      STATS_INFO,
-      REPLICATION_INFO,
-      CPU_INFO,
-      KEYSPACE_INFO,
-    ].inject({}) { |memo, info| memo.merge(info) }
-
-    ALL_INFO = [
-      DEFAULT_INFO,
-      COMMAND_STATS_COMBINED_INFO,
-    ].inject({}) { |memo, info| memo.merge(info) }
+    SECTIONS = {
+      server: SERVER_INFO,
+      clients: CLIENTS_INFO,
+      memory: MEMORY_INFO,
+      persistence: PERSISTENCE_INFO,
+      stats: STATS_INFO,
+      replication: REPLICATION_INFO,
+      cpu: CPU_INFO,
+      keyspace: KEYSPACE_INFO,
+      commandstats: COMMAND_STATS_COMBINED_INFO,
+    }.freeze
+    SECTION_NAMES = {
+      server: 'Server',
+      clients: 'Clients',
+      memory: 'Memory',
+      persistence: 'Persistence',
+      stats: 'Stats',
+      replication: 'Replication',
+      cpu: 'Cpu',
+      keyspace: 'Keyspace',
+      commandstats: 'Commandstats',
+    }.freeze
+    DEFAULT_SECTIONS = [
+      :server, :clients, :memory, :persistence, :stats, :replication, :cpu, :keyspace
+    ].freeze
+    ALL_SECTIONS = DEFAULT_SECTIONS + [:commandstats].freeze
 
     def info(section = :default)
-      section = section.to_sym if section.is_a?(String)
+      if section.to_s.downcase == 'commandstats'
+        # `redis.info(:commandstats)` gives a nested hash structure,
+        # unlike when commandstats is printed as part of `redis.info(:all)`
+        COMMAND_STATS_SOLO_INFO
+      else
+        sections = relevant_info_sections(section)
+        sections.inject({}) { |memo, name| memo.merge(SECTIONS[name]) }
+      end
+    end
+
+    private
+
+    # Format info hash as raw string (used by call("info"))
+    def info_raw(section = :default)
+      sections = relevant_info_sections(section)
+      sections.map do |name|
+        header = "# #{SECTION_NAMES[name]}"
+        lines = SECTIONS[name].map { |k, v| "#{k}:#{v}" }
+        [header, *lines].join("\n")
+      end.join("\n\n") << "\n"
+    end
+
+    def relevant_info_sections(section)
+      section = section.to_s.downcase.to_sym
       case section
-      when :default;      DEFAULT_INFO
-      when :all;          ALL_INFO
-      when :server;       SERVER_INFO
-      when :clients;      CLIENTS_INFO
-      when :memory;       MEMORY_INFO
-      when :persistence;  PERSISTENCE_INFO
-      when :stats;        STATS_INFO
-      when :replication;  REPLICATION_INFO
-      when :cpu;          CPU_INFO
-      when :keyspace;     KEYSPACE_INFO
-      when :commandstats; COMMAND_STATS_SOLO_INFO
+      when :default
+        DEFAULT_SECTIONS
+      when :all
+        ALL_SECTIONS
+      else
+        [section]
       end
     end
   end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -60,12 +60,18 @@ RSpec.describe '#info [mock only]' do
     expect(redis.info(:commandstats)['sunionstore']['usec']).to be_a(String)
   end
 
-  it 'works when called through call method' do
-    expect(redis.call('info')).to be_a(Hash)
+  it 'returns raw string when called through call method' do
+    result = redis.call('info')
+    expect(result).to be_a(String)
+    expect(result).to include('# Server')
+    expect(result).to include('arch_bits:64')
   end
 
-  it 'works when called through call method with section' do
-    info = redis.call('info', 'server')
-    expect(info['arch_bits']).to be_a(String)
+  it 'returns raw string with section when called through call method' do
+    result = redis.call('info', 'server')
+    expect(result).to be_a(String)
+    expect(result).to include('# Server')
+    expect(result).to include('arch_bits:64')
+    expect(result).not_to include('# Clients')
   end
 end


### PR DESCRIPTION
Previously `call(:info)` would fail:

```
> MockRedis.new.call :info
(foo):3 in '<main>': undefined method 'i' for an instance of MockRedis::Database (NoMethodError)
  public_send(command[0].downcase, *command[1..])
```

I fixed that by flattening the arguments passed to `Database#call` ... but noticed that actually, `call(:info)` ought to return a raw string rather than a parsed hash. How about something like this?