### PR TITLE
Add (B)ZMPOP, BZPOPMIN, and BZPOPMAX commands

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -281,6 +281,64 @@ class MockRedis
       end
     end
 
+    def zmpop(*keys, **options)
+      keys.each do |key|
+        assert_zsety(key)
+      end
+
+      modifier = options.is_a?(Hash) && options[:modifier]&.to_s&.downcase || 'min'
+      count = (options.is_a?(Hash) && options[:count]) || 1
+
+      unless %w[min max].include?(modifier)
+        raise ArgumentError, 'Pick either MIN or MAX'
+      end
+
+      keys.each do |key|
+        record_count = zcard(key)
+        next if record_count.zero?
+
+        values = [count, record_count].min.times.map do
+          modifier == 'min' ? zpopmin(key) : zpopmax(key)
+        end
+
+        return [key, values]
+      end
+
+      nil
+    end
+
+    def bzmpop(timeout, *keys, **options)
+      timeout = assert_valid_timeout(timeout)
+
+      keys.each do |key|
+        assert_zsety(key)
+      end
+
+      modifier = options.is_a?(Hash) && options[:modifier]&.to_s&.downcase || 'min'
+      count = (options.is_a?(Hash) && options[:count]) || 1
+
+      unless %w[min max].include?(modifier)
+        raise ArgumentError, 'Pick either MIN or MAX'
+      end
+
+      keys.each do |key|
+        record_count = zcard(key)
+        next if record_count.zero?
+
+        values = [count, record_count].min.times.map do
+          modifier == 'min' ? zpopmin(key) : zpopmax(key)
+        end
+
+        return [key, values]
+      end
+
+      if timeout > 0
+        nil
+      else
+        raise MockRedis::WouldBlock, "Can't block forever"
+      end
+    end
+
     private
 
     def apply_limit(collection, limit)

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -253,6 +253,34 @@ class MockRedis
       zcard(destination)
     end
 
+    def bzpopmin(*args)
+      keys, timeout = extract_timeout(args)
+      nonempty_zset = first_nonempty_zset(keys)
+
+      if nonempty_zset
+        member, score = zpopmin(nonempty_zset)
+        [nonempty_zset, member, score]
+      elsif timeout > 0
+        nil
+      else
+        raise MockRedis::WouldBlock, "Can't block forever"
+      end
+    end
+
+    def bzpopmax(*args)
+      keys, timeout = extract_timeout(args)
+      nonempty_zset = first_nonempty_zset(keys)
+
+      if nonempty_zset
+        member, score = zpopmax(nonempty_zset)
+        [nonempty_zset, member, score]
+      elsif timeout > 0
+        nil
+      else
+        raise MockRedis::WouldBlock, "Can't block forever"
+      end
+    end
+
     private
 
     def apply_limit(collection, limit)
@@ -375,6 +403,10 @@ class MockRedis
       [min, max].each do |value|
         assert_scorey(value, 'ERR min or max is not a float')
       end
+    end
+
+    def first_nonempty_zset(keys)
+      keys.find { |k| zcard(k) > 0 }
     end
   end
 end

--- a/spec/commands/bzmpop_spec.rb
+++ b/spec/commands/bzmpop_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+RSpec.describe '#bzmpop(*keys)', redis: 7.0 do
+  before do
+    @zset1 = 'mock-redis-test:bzmpop-zset'
+    @zset2 = 'mock-redis-test:bzmpop-zset2'
+
+    @redises.zadd(@zset1, 1, 'one')
+    @redises.zadd(@zset1, 2, 'two')
+    @redises.zadd(@zset1, 3, 'three')
+
+    @redises.zadd(@zset2, 10, 'ten')
+    @redises.zadd(@zset2, 11, 'eleven')
+    @redises.zadd(@zset2, 12, 'twelve')
+  end
+
+  it 'returns and removes the lowest scored element of the first non-empty zset' do
+    expect(@redises.bzmpop(1, 'empty', @zset1, @zset2)).to eq([@zset1, [['one', 1.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['two', 2.0], ['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes the lowest scored element when modifier is MIN' do
+    expect(@redises.bzmpop(1, 'empty', @zset1, @zset2, modifier: 'MIN'))
+      .to eq([@zset1, [['one', 1.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['two', 2.0], ['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes the highest scored element when modifier is MAX' do
+    expect(@redises.bzmpop(1, 'empty', @zset1, @zset2, modifier: 'MAX'))
+      .to eq([@zset1, [['three', 3.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['one', 1.0], ['two', 2.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes multiple elements from the min when count is given' do
+    expect(@redises.bzmpop(1, 'empty', @zset1, @zset2, count: 2))
+      .to eq([@zset1, [['one', 1.0], ['two', 2.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes multiple elements from the max when count given and modifier is MAX' do
+    expect(@redises.bzmpop(1, 'empty', @zset1, @zset2, count: 2, modifier: 'MAX')).to(
+      eq([@zset1, [['three', 3.0], ['two', 2.0]]])
+    )
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['one', 1.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'raises an error for non-zset source value' do
+    @redises.set(@zset1, 'string value')
+
+    expect do
+      @redises.bzmpop(1, @zset1, @zset2)
+    end.to raise_error(Redis::WrongTypeError)
+  end
+
+  it 'raises an error for invalid modifier' do
+    expect do
+      @redises.bzmpop(1, @zset1, modifier: 'INVALID')
+    end.to raise_error(ArgumentError)
+  end
+
+  it 'raises an error on negative timeout' do
+    expect do
+      @redises.bzmpop(-1, @zset1, @zset2)
+    end.to raise_error(ArgumentError)
+  end
+
+  it 'raises an error for non-zset values in the key list' do
+    @redises.set('string-key', 'value')
+
+    expect do
+      @redises.bzmpop(1, 'string-key')
+    end.to raise_error(Redis::WrongTypeError)
+  end
+
+  context '[mock only]' do
+    it 'ignores positive timeouts and returns nil when all zsets are empty' do
+      expect(@redises.mock.bzmpop(1, 'empty')).to be_nil
+    end
+
+    it 'raises WouldBlock on zero timeout when all zsets are empty' do
+      expect do
+        @redises.mock.bzmpop(0, 'empty')
+      end.to raise_error(MockRedis::WouldBlock)
+    end
+  end
+end

--- a/spec/commands/bzpopmax_spec.rb
+++ b/spec/commands/bzpopmax_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe '#bzpopmax(key [, key, ...,], timeout)' do
+  before do
+    @zset1 = 'mock-redis-test:bzpopmax1'
+    @zset2 = 'mock-redis-test:bzpopmax2'
+
+    @redises.zadd(@zset1, 1, 'one')
+    @redises.zadd(@zset1, 2, 'two')
+    @redises.zadd(@zset2, 10, 'ten')
+    @redises.zadd(@zset2, 11, 'eleven')
+  end
+
+  it 'returns [first-nonempty-zset, popped-member, score]' do
+    expect(@redises.bzpopmax(@zset1, @zset2)).to eq([@zset1, 'two', 2.0])
+  end
+
+  it 'pops that value off the sorted set' do
+    @redises.bzpopmax(@zset1, @zset2)
+    @redises.bzpopmax(@zset1, @zset2)
+
+    expect(@redises.bzpopmax(@zset1, @zset2)).to eq([@zset2, 'eleven', 11.0])
+  end
+
+  it 'ignores empty keys' do
+    expect(@redises.bzpopmax('mock-redis-test:not-here', @zset1)).to eq(
+      [@zset1, 'two', 2.0]
+    )
+  end
+
+  it 'raises an error on negative timeout' do
+    expect do
+      @redises.bzpopmax(@zset1, @zset2, :timeout => -1)
+    end.to raise_error(ArgumentError)
+  end
+
+  it_should_behave_like 'a zset-only command'
+
+  context '[mock only]' do
+    it 'ignores positive timeouts and returns nil' do
+      expect(@redises.mock.bzpopmax('mock-redis-test:not-here', :timeout => 1)).to be_nil
+    end
+
+    it 'ignores positive legacy timeouts and returns nil' do
+      expect(@redises.mock.bzpopmax('mock-redis-test:not-here', 1)).to be_nil
+    end
+
+    it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
+      expect do
+        @redises.mock.bzpopmax('mock-redis-test:not-here', :timeout => 0)
+      end.to raise_error(MockRedis::WouldBlock)
+    end
+  end
+end

--- a/spec/commands/bzpopmin_spec.rb
+++ b/spec/commands/bzpopmin_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe '#bzpopmin(key [, key, ...,], timeout)' do
+  before do
+    @zset1 = 'mock-redis-test:bzpopmin1'
+    @zset2 = 'mock-redis-test:bzpopmin2'
+
+    @redises.zadd(@zset1, 1, 'one')
+    @redises.zadd(@zset1, 2, 'two')
+    @redises.zadd(@zset2, 10, 'ten')
+    @redises.zadd(@zset2, 11, 'eleven')
+  end
+
+  it 'returns [first-nonempty-zset, popped-member, score]' do
+    expect(@redises.bzpopmin(@zset1, @zset2)).to eq([@zset1, 'one', 1.0])
+  end
+
+  it 'pops that value off the sorted set' do
+    @redises.bzpopmin(@zset1, @zset2)
+    @redises.bzpopmin(@zset1, @zset2)
+
+    expect(@redises.bzpopmin(@zset1, @zset2)).to eq([@zset2, 'ten', 10.0])
+  end
+
+  it 'ignores empty keys' do
+    expect(@redises.bzpopmin('mock-redis-test:not-here', @zset1)).to eq(
+      [@zset1, 'one', 1.0]
+    )
+  end
+
+  it 'raises an error on negative timeout' do
+    expect do
+      @redises.bzpopmin(@zset1, @zset2, :timeout => -1)
+    end.to raise_error(ArgumentError)
+  end
+
+  it_should_behave_like 'a zset-only command'
+
+  context '[mock only]' do
+    it 'ignores positive timeouts and returns nil' do
+      expect(@redises.mock.bzpopmin('mock-redis-test:not-here', :timeout => 1)).to be_nil
+    end
+
+    it 'ignores positive legacy timeouts and returns nil' do
+      expect(@redises.mock.bzpopmin('mock-redis-test:not-here', 1)).to be_nil
+    end
+
+    it 'raises WouldBlock on zero timeout (no blocking in the mock)' do
+      expect do
+        @redises.mock.bzpopmin('mock-redis-test:not-here', :timeout => 0)
+      end.to raise_error(MockRedis::WouldBlock)
+    end
+  end
+end

--- a/spec/commands/zmpop_spec.rb
+++ b/spec/commands/zmpop_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+RSpec.describe '#zmpop(*keys)', redis: 7.0 do
+  before do
+    @zset1 = 'mock-redis-test:zmpop-zset'
+    @zset2 = 'mock-redis-test:zmpop-zset2'
+
+    @redises.zadd(@zset1, 1, 'one')
+    @redises.zadd(@zset1, 2, 'two')
+    @redises.zadd(@zset1, 3, 'three')
+
+    @redises.zadd(@zset2, 10, 'ten')
+    @redises.zadd(@zset2, 11, 'eleven')
+    @redises.zadd(@zset2, 12, 'twelve')
+  end
+
+  it 'returns and removes the lowest scored element of the first non-empty zset' do
+    expect(@redises.zmpop('empty', @zset1, @zset2))
+      .to eq([@zset1, [['one', 1.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['two', 2.0], ['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes the lowest scored element when modifier is MIN' do
+    expect(@redises.zmpop('empty', @zset1, @zset2, modifier: 'MIN'))
+      .to eq([@zset1, [['one', 1.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['two', 2.0], ['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes the highest scored element when modifier is MAX' do
+    expect(@redises.zmpop('empty', @zset1, @zset2, modifier: 'MAX'))
+      .to eq([@zset1, [['three', 3.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['one', 1.0], ['two', 2.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes multiple elements from the min when count is given' do
+    expect(@redises.zmpop('empty', @zset1, @zset2, count: 2))
+      .to eq([@zset1, [['one', 1.0], ['two', 2.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns and removes multiple elements from the max when count given and modifier is MAX' do
+    expect(@redises.zmpop('empty', @zset1, @zset2, count: 2, modifier: 'MAX'))
+      .to eq([@zset1, [['three', 3.0], ['two', 2.0]]])
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['one', 1.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'returns nil if all zsets are empty' do
+    expect(@redises.zmpop('empty')).to be_nil
+
+    expect(@redises.zrange(@zset1, 0, -1, with_scores: true))
+      .to eq([['one', 1.0], ['two', 2.0], ['three', 3.0]])
+
+    expect(@redises.zrange(@zset2, 0, -1, with_scores: true))
+      .to eq([['ten', 10.0], ['eleven', 11.0], ['twelve', 12.0]])
+  end
+
+  it 'removes empty zsets' do
+    (@redises.zcard(@zset1) + @redises.zcard(@zset2)).times { @redises.zmpop(@zset1, @zset2) }
+    expect(@redises.get(@zset1)).to be_nil
+  end
+
+  it 'raises an error for non-zset source value' do
+    @redises.set(@zset1, 'string value')
+
+    expect do
+      @redises.zmpop(@zset1, @zset2)
+    end.to raise_error(Redis::WrongTypeError)
+  end
+
+  it 'raises an error for invalid modifier' do
+    expect do
+      @redises.zmpop(@zset1, modifier: 'INVALID')
+    end.to raise_error(ArgumentError)
+  end
+
+  it_should_behave_like 'a zset-only command'
+end


### PR DESCRIPTION
Add support for the following zset commands:
- ZMPOP: Pops one or more elements, that are member-score pairs, from the first non-empty sorted set in the provided list of key names
- BZMPOP: blocking variant of ZMPOP
- BZPOPMIN: blocking variant of ZPOPMIN
- BZPOPMAX: blocking variant of ZPOPMAX