### PR TITLE
[Feature] Add gt option for zadd method at sorted set

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -42,12 +42,20 @@ class MockRedis
         if zadd_options[:incr]
           if zadd_options[:gt]
             current_score = zset.score(member.to_s)
-            if current_score.nil?
-              return zadd_options[:xx] ? nil : zincrby(key, score, member)
-            else
-              new_score = current_score + score.to_f
-              return new_score > current_score ? zincrby(key, score, member) : nil
-            end
+
+            # NOTE: does nothing if the member doesn't exist and XX option is set.
+            return nil if current_score.nil? && zadd_options[:xx]
+
+            # NOTE: zincrby add the increment if the member doesn't exist and XX option is not set.
+            return zincrby(key, score, member) if current_score.nil? && !zadd_options[:xx]
+
+            new_score = current_score + score.to_f
+
+            # NOTE: does nothing if the new score is not greater than the current score.
+            return nil if current_score && new_score <= current_score
+
+            # NOTE: zincrby update the score if the new score is greater than the current score.
+            return zincrby(key, score, member)
           end
 
           if zadd_options[:xx]
@@ -67,7 +75,7 @@ class MockRedis
 
           if current_score.nil?
             return false if zadd_options[:xx]
-             
+
             zset.add(new_score, member.to_s)
             true
           else

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -18,6 +18,13 @@ class MockRedis
         )
       end
 
+      if zadd_options&.include?(:gt) && zadd_options&.include?(:nx)
+        raise Error.command_error(
+          'ERR GT, LT, and/or NX options at the same time are not compatible',
+          self
+        )
+      end
+
       if args.size == 1 && args[0].is_a?(Array)
         zadd_multiple_members(key, args.first, zadd_options)
       elsif args.size == 2
@@ -49,6 +56,16 @@ class MockRedis
           false
         elsif zadd_options[:nx]
           !zset.include?(member) && !!zset.add(score, member.to_s)
+        elsif zadd_options[:gt]
+          current_score = zset.score(member.to_s)
+          if current_score.nil?
+            zset.add(score.to_f, member.to_s)
+            true
+          else
+            score_f = score.to_f
+            zset.add(score_f, member.to_s) if score_f > current_score
+            false
+          end
         else
           retval = !zscore(key, member)
           zset.add(score, member.to_s)

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -51,21 +51,25 @@ class MockRedis
           end
 
           zincrby(key, score, member)
+        elsif zadd_options[:gt]
+          current_score = zset.score(member.to_s)
+          new_score = score.to_f
+
+          if current_score.nil?
+            return false if zadd_options[:xx]
+             
+            zset.add(new_score, member.to_s)
+            true
+          else
+            zset.add(new_score, member.to_s) if new_score > current_score
+            false
+          end
         elsif zadd_options[:xx]
+          # NOTE: gt and xx options are handled at the gt branch above, so its not handled here.
           zset.add(score, member.to_s) if zset.include?(member)
           false
         elsif zadd_options[:nx]
           !zset.include?(member) && !!zset.add(score, member.to_s)
-        elsif zadd_options[:gt]
-          current_score = zset.score(member.to_s)
-          if current_score.nil?
-            zset.add(score.to_f, member.to_s)
-            true
-          else
-            score_f = score.to_f
-            zset.add(score_f, member.to_s) if score_f > current_score
-            false
-          end
         else
           retval = !zscore(key, member)
           zset.add(score, member.to_s)

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -40,6 +40,16 @@ class MockRedis
 
       with_zset_at(key) do |zset|
         if zadd_options[:incr]
+          if zadd_options[:gt]
+            current_score = zset.score(member.to_s)
+            if current_score.nil?
+              return zadd_options[:xx] ? nil : zincrby(key, score, member)
+            else
+              new_score = current_score + score.to_f
+              return new_score > current_score ? zincrby(key, score, member) : nil
+            end
+          end
+
           if zadd_options[:xx]
             member_present = zset.include?(member)
             return member_present ? zincrby(key, score, member) : nil

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -98,6 +98,20 @@ class MockRedis
             'ERR INCR option supports a single increment-element pair',
             self
           )
+        elsif zadd_options[:gt]
+          args.reduce(0) do |retval, (score, member)|
+            current_score = zset.score(member.to_s)
+            if current_score.nil?
+              unless zadd_options[:xx]
+                zset.add(score.to_f, member.to_s)
+                retval += 1
+              end
+            else
+              score_f = score.to_f
+              zset.add(score_f, member.to_s) if score_f > current_score
+            end
+            retval
+          end
         elsif zadd_options[:xx]
           args.each { |score, member| zset.include?(member) && zset.add(score, member.to_s) }
           0

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -136,6 +136,39 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'foo')).to eq(5.0)
   end
 
+  it 'with GT and INCR adds new member with increment as initial score' do
+    result = @redises.zadd(@key, 5, 'foo', gt: true, incr: true)
+    expect(result).to eq(5.0)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+  end
+
+  it 'with GT and INCR updates existing member when positive increment makes score greater' do
+    @redises.zadd(@key, 3, 'foo')
+    result = @redises.zadd(@key, 2, 'foo', gt: true, incr: true)
+    expect(result).to eq(5.0)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+  end
+
+  it 'with GT and INCR does not update existing member when negative increment makes score lower' do
+    @redises.zadd(@key, 3, 'foo')
+    result = @redises.zadd(@key, -1, 'foo', gt: true, incr: true)
+    expect(result).to be_nil
+    expect(@redises.zscore(@key, 'foo')).to eq(3.0)
+  end
+
+  it 'with GT and INCR and XX, member does not exist, does not add new member' do
+    result = @redises.zadd(@key, 5, 'foo', gt: true, incr: true, xx: true)
+    expect(result).to be_nil
+    expect(@redises.zscore(@key, 'foo')).to be_nil
+  end
+
+  it 'with GT and INCR and XX updates existing member when positive increment makes score greater' do
+    @redises.zadd(@key, 3, 'foo')
+    result = @redises.zadd(@key, 2, 'foo', gt: true, incr: true, xx: true)
+    expect(result).to eq(5.0)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+  end
+
   it 'with INCR is act like zincrby' do
     expect(@redises.zadd(@key, 10, 'bert', incr: true)).to eq(10.0)
     expect(@redises.zadd(@key, 3, 'bert', incr: true)).to eq(13.0)

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'foo')).to be_nil
   end
 
-  it 'with GT and INCR and XX updates existing member when positive increment makes score greater' do
+  it 'with GT, INCR and XX updates existing member when positive increment makes score greater' do
     @redises.zadd(@key, 3, 'foo')
     result = @redises.zadd(@key, 2, 'foo', gt: true, incr: true, xx: true)
     expect(result).to eq(5.0)
@@ -206,7 +206,7 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'bar')).to eq(1.0)
   end
 
-  it 'with GT option and multiple members does not update existing member when new score is lower' do
+  it 'with GT option, multiple members does not update existing member, when new score is lower' do
     @redises.zadd(@key, 3, 'foo')
     count = @redises.zadd(@key, [[1, 'foo'], [2, 'bar']], gt: true)
     expect(count).to eq(1)
@@ -214,7 +214,7 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'bar')).to eq(2.0)
   end
 
-  it 'with GT and XX options and multiple members, when member does not exist, does not add new members' do
+  it 'with GT and XX options, multiple members and member doesnt exist, doesnt add new members' do
     @redises.zadd(@key, 1, 'foo')
     count = @redises.zadd(@key, [[5, 'foo'], [9, 'bar']], gt: true, xx: true)
     expect(count).to eq(0)

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'foo')).to eq(3.0)
   end
 
+  it 'with GT and XX options, member does not does not add new member' do
+    result = @redises.zadd(@key, 1, 'foo', gt: true, xx: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to be_nil
+  end
+
+  it 'with GT and XX options updates existing member when new score is greater' do
+    @redises.zadd(@key, 1, 'foo')
+    result = @redises.zadd(@key, 5, 'foo', gt: true, xx: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+  end
+
+  it 'with GT and XX options does not update existing member when new score is lower' do
+    @redises.zadd(@key, 5, 'foo')
+    result = @redises.zadd(@key, 1, 'foo', gt: true, xx: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+  end
+
   it 'with INCR is act like zincrby' do
     expect(@redises.zadd(@key, 10, 'bert', incr: true)).to eq(10.0)
     expect(@redises.zadd(@key, 3, 'bert', incr: true)).to eq(13.0)

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -83,6 +83,39 @@ RSpec.describe '#zadd(key, score, member)' do
     end.to raise_error(Redis::CommandError)
   end
 
+  it 'with GT and NX options at the same time raise error' do
+    expect do
+      @redises.zadd(@key, 1, 'foo', gt: true, nx: true)
+    end.to raise_error(Redis::CommandError)
+  end
+
+  it 'with GT option adds new member' do
+    result = @redises.zadd(@key, 1, 'foo', gt: true)
+    expect(result).to eq(true)
+    expect(@redises.zscore(@key, 'foo')).to eq(1.0)
+  end
+
+  it 'with GT option updates existing member when new score is greater' do
+    @redises.zadd(@key, 1, 'foo')
+    result = @redises.zadd(@key, 2, 'foo', gt: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to eq(2.0)
+  end
+
+  it 'with GT option does not update existing member when new score is equal' do
+    @redises.zadd(@key, 2, 'foo')
+    result = @redises.zadd(@key, 2, 'foo', gt: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to eq(2.0)
+  end
+
+  it 'with GT option does not update existing member when new score is lower' do
+    @redises.zadd(@key, 3, 'foo')
+    result = @redises.zadd(@key, 1, 'foo', gt: true)
+    expect(result).to eq(false)
+    expect(@redises.zscore(@key, 'foo')).to eq(3.0)
+  end
+
   it 'with INCR is act like zincrby' do
     expect(@redises.zadd(@key, 10, 'bert', incr: true)).to eq(10.0)
     expect(@redises.zadd(@key, 3, 'bert', incr: true)).to eq(13.0)

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -198,6 +198,30 @@ RSpec.describe '#zadd(key, score, member)' do
     end.to raise_error(Redis::CommandError)
   end
 
+  it 'with GT option and multiple members counts only newly added members' do
+    @redises.zadd(@key, 3, 'foo')
+    count = @redises.zadd(@key, [[5, 'foo'], [1, 'bar']], gt: true)
+    expect(count).to eq(1)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+    expect(@redises.zscore(@key, 'bar')).to eq(1.0)
+  end
+
+  it 'with GT option and multiple members does not update existing member when new score is lower' do
+    @redises.zadd(@key, 3, 'foo')
+    count = @redises.zadd(@key, [[1, 'foo'], [2, 'bar']], gt: true)
+    expect(count).to eq(1)
+    expect(@redises.zscore(@key, 'foo')).to eq(3.0)
+    expect(@redises.zscore(@key, 'bar')).to eq(2.0)
+  end
+
+  it 'with GT and XX options and multiple members, when member does not exist, does not add new members' do
+    @redises.zadd(@key, 1, 'foo')
+    count = @redises.zadd(@key, [[5, 'foo'], [9, 'bar']], gt: true, xx: true)
+    expect(count).to eq(0)
+    expect(@redises.zscore(@key, 'foo')).to eq(5.0)
+    expect(@redises.zscore(@key, 'bar')).to be_nil
+  end
+
   it 'supports a variable number of arguments' do
     @redises.zadd(@key, [[1, 'one'], [2, 'two']])
     @redises.zadd(@key, [[3, 'three']])

--- a/spec/commands/zadd_spec.rb
+++ b/spec/commands/zadd_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe '#zadd(key, score, member)' do
     expect(@redises.zscore(@key, 'foo')).to eq(3.0)
   end
 
-  it 'with GT and XX options, member does not does not add new member' do
+  it 'with GT and XX options, member does not exist, does not add new member' do
     result = @redises.zadd(@key, 1, 'foo', gt: true, xx: true)
     expect(result).to eq(false)
     expect(@redises.zscore(@key, 'foo')).to be_nil


### PR DESCRIPTION
Hi there, I am using `mock-redis` for our app's test environment. We are looking to leverage `zadd` with the `gt` option from Redis for a caching use case. I found out that `mock-redis` does not implement the `gt` option for `zadd` the moment and took sometime to implement it in my fork.

I implemented the `gt` option to `zadd`, having referred to the current official [documentation](https://redis.io/docs/latest/commands/zadd/) and used a couple of AI conversations to get an understanding of the various edge cases before adding and committing the code in.

I've also validated that invocation of `zadd` with `gt` option does work accordingly in the new specs added in the feature branch that I'm developing right now.

# Changes

1. Add support for `gt` for single member and multi member `zadd` usages
2. Raise command error when both `gt` and `nx` options are included in the same `zadd` invocation.
3. Support `gt` usages together with `xx` option, moving the branches handling `nx` and `xx` downwards, respecting the current code structure.
4. Add support for `incr` option while using the `gt` option in both single and multi member `zadd` invocation. 

# Test

1. Multiple `it` blocks covering the changes and edge cases when any of `gt`, `xx` and `nx` are included.

---

Hope you can take sometime to review and let me know what changes might be desired for this to get merged. 🙏 